### PR TITLE
Homepage blueprint graphics + animated section reveals

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,6 +17,7 @@
   --color-accent-secondary: #b4b4b4;
   --color-border: #2a2b30;
   --color-border-light: #3a3b40;
+  --color-line: #6e7078;
   --grid: 24px;
   --grid-dot: #2a2b30;
   --grid-line: #2e2f36;
@@ -245,6 +246,210 @@ body {
   .icon-spin-slow {
     animation: none;
     opacity: 1;
+  }
+}
+
+/* ─── Blueprint graphic draw-in + ongoing loops ───
+   Powers the homepage schematics (<BlueprintGraphic>). Three element roles,
+   tagged in the SVG body:
+     .bp-line — structural strokes; draw in via stroke-dashoffset, staggered by --draw-i.
+     .bp-node — the single accent highlight; snaps in (opacity + scale) after the lines.
+     .bp-fx   — loop-dedicated elements (flow line, scan bar, gear); fade in, then loop.
+   The wrapper toggles data-visible='true' on first scroll into view. --bp-draw-base
+   offsets the whole sequence (the hero piece uses it to start after its intro). */
+.bp-draw .bp-line {
+  stroke-dasharray: 200;
+  stroke-dashoffset: 200;
+  transition: stroke-dashoffset 900ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition-delay: calc(var(--bp-draw-base, 0ms) + var(--draw-i, 0) * 120ms);
+}
+.bp-draw[data-visible='true'] .bp-line {
+  stroke-dashoffset: 0;
+}
+
+.bp-draw .bp-node {
+  opacity: 0;
+  transform: scale(0.4);
+  transform-box: fill-box;
+  transform-origin: center;
+  transition:
+    opacity 400ms ease-out,
+    transform 460ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition-delay: calc(var(--bp-draw-base, 0ms) + var(--draw-i, 0) * 120ms + 640ms);
+}
+.bp-draw[data-visible='true'] .bp-node {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.bp-draw .bp-fx {
+  opacity: 0;
+  transition: opacity 500ms ease-out;
+  transition-delay: calc(var(--bp-draw-base, 0ms) + 800ms);
+}
+.bp-draw[data-visible='true'] .bp-fx {
+  opacity: 1;
+}
+
+/* Ongoing loops — start only once visible, and after the draw-in has finished. */
+@keyframes bp-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.55;
+    transform: scale(0.8);
+  }
+}
+.bp-loop-pulse[data-visible='true'] .bp-node {
+  animation: bp-pulse 4.5s ease-in-out infinite;
+  animation-delay: calc(var(--bp-draw-base, 0ms) + 1000ms);
+}
+
+@keyframes bp-breathe {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 0 rgba(181, 245, 66, 0));
+  }
+  50% {
+    filter: drop-shadow(0 0 5px rgba(181, 245, 66, 0.5));
+  }
+}
+.bp-loop-breathe[data-visible='true'] .bp-node {
+  animation: bp-breathe 4s ease-in-out infinite;
+  animation-delay: calc(var(--bp-draw-base, 0ms) + 1000ms);
+}
+
+/* Marching dashes along an accent guide line (element sets its own dasharray). */
+@keyframes bp-flow {
+  to {
+    stroke-dashoffset: -32;
+  }
+}
+.bp-loop-travel[data-visible='true'] .bp-flow {
+  animation: bp-flow 1.6s linear infinite;
+  animation-delay: calc(var(--bp-draw-base, 0ms) + 1200ms);
+}
+
+@keyframes bp-scan {
+  0% {
+    transform: translateY(-6px);
+    opacity: 0;
+  }
+  20%,
+  80% {
+    opacity: 0.7;
+  }
+  100% {
+    transform: translateY(30px);
+    opacity: 0;
+  }
+}
+.bp-loop-scan[data-visible='true'] .bp-scan {
+  animation: bp-scan 6s ease-in-out infinite;
+  animation-delay: calc(var(--bp-draw-base, 0ms) + 1200ms);
+}
+
+.bp-loop-gear[data-visible='true'] .bp-gear {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: icon-spin-slow 16s linear infinite;
+  animation-delay: calc(var(--bp-draw-base, 0ms) + 1200ms);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bp-draw .bp-line,
+  .bp-draw .bp-node,
+  .bp-draw .bp-fx {
+    transition: none;
+    stroke-dashoffset: 0;
+    opacity: 1;
+    transform: none;
+  }
+  .bp-loop-pulse .bp-node,
+  .bp-loop-breathe .bp-node,
+  .bp-loop-travel .bp-flow,
+  .bp-loop-scan .bp-scan,
+  .bp-loop-gear .bp-gear {
+    animation: none;
+  }
+}
+
+/* ─── Hero story timeline ───
+   The hero's looping five-beat story (<HeroGraphic>). A JS beat sequencer sets
+   per-element opacity/transform inline; these rules tween it. Namespaced under
+   [data-hero-story] so they can't collide with the .bp-* schematic system. */
+[data-hero-story] .hs-anim {
+  transition:
+    opacity 600ms ease,
+    transform 850ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes hs-breathe {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 0 rgba(181, 245, 66, 0));
+  }
+  50% {
+    filter: drop-shadow(0 0 5px rgba(181, 245, 66, 0.55));
+  }
+}
+[data-hero-story] .hs-core {
+  animation: hs-breathe 4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-hero-story] .hs-anim {
+    transition: none;
+  }
+  [data-hero-story] .hs-core {
+    animation: none;
+  }
+}
+
+/* ─── Auto-scrolling trust banner ───
+   A seamless vendor marquee. Items are rendered twice inside .marquee-track and
+   the track slides by -50% (one full copy) on a loop. .marquee-track-rev runs the
+   same keyframe in reverse for the opposite direction. Edges fade via a mask. */
+.marquee {
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 6%, #000 94%, transparent);
+  mask-image: linear-gradient(to right, transparent, #000 6%, #000 94%, transparent);
+}
+.marquee-track {
+  display: flex;
+  width: max-content;
+  animation: marquee-scroll 48s linear infinite;
+}
+.marquee-track-rev {
+  animation-direction: reverse;
+  animation-duration: 40s;
+}
+@keyframes marquee-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+.marquee:hover .marquee-track {
+  animation-play-state: paused;
+}
+/* Slower scroll on mobile, where the two rows are more prominent. */
+@media (max-width: 767px) {
+  .marquee-track {
+    animation-duration: 80s;
+  }
+  .marquee-track-rev {
+    animation-duration: 68s;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .marquee-track {
+    animation: none;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -377,6 +377,54 @@ body {
   }
 }
 
+/* ─── Hero comparison set piece ───
+   "Built for everyone" vs "Built for you". Each dashboard/arrow group (.cmp-in)
+   fades and rises in sequence via an inline --cmp-delay: the three generic
+   dashboards one by one, then the arrow, then your app last. The one live widget
+   (.cmp-live) breathes once everything has settled. The whole sequence is offset
+   by --bp-draw-base so it starts after the hero intro. */
+.hero-compare .cmp-in {
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    opacity 650ms ease,
+    transform 750ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition-delay: calc(var(--bp-draw-base, 0ms) + var(--cmp-delay, 0ms));
+}
+.hero-compare[data-visible='true'] .cmp-in {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes cmp-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scale(0.92);
+  }
+}
+.hero-compare[data-visible='true'] .cmp-live {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: cmp-pulse 4.5s ease-in-out infinite;
+  animation-delay: calc(var(--bp-draw-base, 0ms) + var(--cmp-live-delay, 1600ms));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-compare .cmp-in {
+    transition: none;
+    opacity: 1;
+    transform: none;
+  }
+  .hero-compare[data-visible='true'] .cmp-live {
+    animation: none;
+  }
+}
+
 /* ─── Hero story timeline ───
    The hero's looping five-beat story (<HeroGraphic>). A JS beat sequencer sets
    per-element opacity/transform inline; these rules tween it. Namespaced under

--- a/src/components/graphics/blueprint-graphic.tsx
+++ b/src/components/graphics/blueprint-graphic.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type SVGProps,
+} from 'react'
+import { cn } from '@/src/lib/utils'
+
+/**
+ * Fires once when the element first scrolls into view. Under prefers-reduced-motion
+ * it resolves to true immediately and skips the observer entirely, mirroring the
+ * short-circuit in AnimatedSection so animated and static behaviour stay consistent.
+ */
+export function useInView<T extends Element = HTMLElement>() {
+  const ref = useRef<T>(null)
+  const [inView, setInView] = useState(false)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setInView(true)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: '0px 0px -15% 0px', threshold: 0.2 }
+    )
+
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, inView }
+}
+
+interface BlueprintGraphicProps extends SVGProps<SVGSVGElement> {
+  /** The schematic body — paths, lines, and one accent `.bp-node`. */
+  children: ReactNode
+  /** Ongoing-loop variant applied once drawn in (e.g. 'bp-loop-pulse'). */
+  loop?: string
+  /**
+   * Delay (ms) before the draw-in starts once in view. The hero piece uses this
+   * to sequence its draw after the hero intro finishes.
+   */
+  drawDelayMs?: number
+}
+
+/**
+ * Client wrapper that draws a blueprint schematic in on first view, then hands
+ * off to a subtle ongoing loop. The SVG body is authored in the shared
+ * process-graphics style (100x100 viewBox, stroke-border-light, one fill-accent
+ * node). All motion + reduced-motion handling lives in globals.css, keyed off the
+ * `bp-draw` class and the `data-visible` attribute this component toggles.
+ */
+export function BlueprintGraphic({
+  children,
+  loop,
+  drawDelayMs,
+  className,
+  style,
+  ...props
+}: BlueprintGraphicProps) {
+  const { ref, inView } = useInView<SVGSVGElement>()
+
+  return (
+    <svg
+      ref={ref}
+      viewBox='0 0 100 100'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      aria-hidden
+      data-visible={inView ? 'true' : undefined}
+      className={cn('bp-draw', loop, className)}
+      style={
+        {
+          ...(drawDelayMs ? { '--bp-draw-base': `${drawDelayMs}ms` } : {}),
+          ...style,
+        } as CSSProperties
+      }
+      {...props}
+    >
+      {children}
+    </svg>
+  )
+}

--- a/src/components/graphics/hero-graphic.tsx
+++ b/src/components/graphics/hero-graphic.tsx
@@ -1,256 +1,247 @@
-'use client'
-
-import { useEffect, useRef, useState, type CSSProperties } from 'react'
-import { useInView } from './blueprint-graphic'
-import { AsanaLogo, MondayLogo, SlackLogo, TrelloLogo, NotionLogo } from './saas-logos'
+import type { CSSProperties, ReactNode } from 'react'
+import { BlueprintGraphic } from './blueprint-graphic'
 
 /**
- * Hero signature piece — a looping four-beat story that plays after the hero
- * intro and repeats, leaning into the "Place to Stand" metaphor: the PTS Portal
- * is the platform, and the user ends up standing on top of it.
- *   0 TOOL OVERLOAD  — the user, centred, tethered to scattered SaaS tools.
- *   1 MEET PTS       — the tools dim; the lime PTS core appears where the user was,
- *                      and the user rises to stand above it (first accent).
- *   2 YOUR DASHBOARD — the tools collapse into the PTS Portal, now a solid platform
- *                      the user stands on.
- *   3 THINK BIGGER   — strategy ideas rise from the user, up off the top.
+ * Hero signature piece — a plain side-by-side that states the headline outright:
+ * off-the-shelf software is built for everyone; we build for you.
  *
- * Self-contained: a JS beat sequencer toggles `beat`; per-element opacity/transform
- * is set inline and CSS (.hs-anim in globals.css) tweens it. Reuses `useInView`
- * for the in-view gate + reduced-motion detection; under reduced motion it parks on
- * beat 2 (user standing on the Portal) with no timer.
+ *   LEFT   "Built for everyone" — a whole stack of generic dashboards fanned
+ *          like cards (many to juggle), the front one overloaded with
+ *          mismatched modules: hatching, a cramped bar chart, dot rows and data
+ *          lines. One-size-fits-all noise, but rendered in the same thin,
+ *          hollow blueprint language as the rest of the site.
+ *   ARROW  annotated with the transition: consolidate + custom fit.
+ *   RIGHT  "Built for you" — one app, pared to a clean sidebar (one active item)
+ *          and a single insight widget: a rising accent trend with a live node.
+ *
+ * Same schematic vocabulary as home-graphics.tsx (fill-bg-card hollow shapes,
+ * stroke-line, one accent highlight). Entrance is a sequenced fade-and-rise
+ * (see .hero-compare in globals.css): the three generic dashboards come up one
+ * by one, then the arrow, then your app last. The wrapper (<BlueprintGraphic>)
+ * only supplies the in-view gate, reduced-motion handling, and the intro offset.
  */
 
-const CAPTIONS = ['TOOL OVERLOAD', 'MEET PTS', 'YOUR DASHBOARD', 'THINK BIGGER']
-const HOLDS = [3200, 2600, 3000, 3400] // ms held on each beat
+/** Sets a group's entrance delay (ms) within the sequenced reveal. */
+const cmp = (delayMs: number) => ({ ['--cmp-delay']: `${delayMs}ms` }) as CSSProperties
 
-// Opacity of each element group per beat [0..3].
-const OP = {
-  logos: [1, 0.4, 0, 0],
-  tethers: [0.7, 0.35, 0, 0],
-  ring: [1, 1, 0, 0], // the hub ring — only while the user is the centre
-  core: [0, 1, 1, 1],
-  portal: [0, 0, 1, 1],
-  thoughts: [0, 0, 0, 1],
-}
+type Rect = { x: number; y: number; w: number; h: number }
 
-const CENTER = { x: 100, y: 94 } // the hub: the user (beat 0), then the Portal core
-const USER = { x: 100, y: 52, r: 17 } // the user's resting spot — standing on top
-const USER_DROP = CENTER.y - USER.y // translateY that drops the user to CENTER for beat 0
-const LOGO_S = 0.7
-const LOGO_O = 12 * LOGO_S // half of the 24-grid glyph, scaled
-
-// Tools orbit the hub.
-const SCATTER = [
-  { x: 100, y: 40 },
-  { x: 151, y: 77 },
-  { x: 132, y: 138 },
-  { x: 68, y: 138 },
-  { x: 49, y: 77 },
+// ── Generic app: overloaded, misaligned modules in the front dashboard. All
+//    hollow; `deco` adds interior noise. Columns align, rows don't. ──
+type Tile = Rect & { deco?: 'hatch' | 'bars' | 'dots' | 'text' }
+const CLUTTER: Tile[] = [
+  { x: 20, y: 51, w: 19, h: 11, deco: 'text' },
+  { x: 20, y: 64, w: 19, h: 15, deco: 'hatch' },
+  { x: 20, y: 81, w: 19, h: 10 },
+  { x: 20, y: 93, w: 19, h: 20, deco: 'bars' },
+  { x: 41, y: 51, w: 19, h: 8 },
+  { x: 41, y: 61, w: 19, h: 17, deco: 'text' },
+  { x: 41, y: 80, w: 19, h: 7, deco: 'dots' },
+  { x: 41, y: 89, w: 19, h: 24, deco: 'hatch' },
+  { x: 62, y: 51, w: 18, h: 16, deco: 'text' },
+  { x: 62, y: 69, w: 18, h: 10 },
+  { x: 62, y: 81, w: 18, h: 12, deco: 'hatch' },
+  { x: 62, y: 95, w: 18, h: 18, deco: 'bars' },
 ]
-const LOGOS = [AsanaLogo, MondayLogo, SlackLogo, TrelloLogo, NotionLogo]
 
-/** Point on a circle of radius r (centre cx,cy) in the direction of (px,py). */
-function edge(cx: number, cy: number, px: number, py: number, r: number) {
-  const dx = px - cx
-  const dy = py - cy
-  const len = Math.hypot(dx, dy) || 1
-  return { x: cx + (dx / len) * r, y: cy + (dy / len) * r }
+/** Diagonal hatch fill (two parallel sets) inside a tile. */
+function hatch({ x, y, w, h }: Rect): ReactNode {
+  const fs = [0.25, 0.5, 0.75, 1]
+  return (
+    <>
+      {fs.map(f => (
+        <line key={`ha${f}`} x1={x + w * f} y1={y} x2={x} y2={y + h * f} className='stroke-line' strokeWidth='0.5' />
+      ))}
+      {fs.map(f => (
+        <line key={`hb${f}`} x1={x + w} y1={y + h * (1 - f)} x2={x + w * (1 - f)} y2={y + h} className='stroke-line' strokeWidth='0.5' />
+      ))}
+    </>
+  )
 }
 
-/** A person, from lucide's `User` bust glyph, placed + scaled at (cx,cy). */
-function Person({ cx, cy, s }: { cx: number; cy: number; s: number }) {
+/** A cramped bar chart inside a tile. */
+function bars({ x, y, w, h }: Rect): ReactNode {
+  const base = y + h - 3
+  const hs = [0.4, 0.7, 0.5, 0.9, 0.6, 0.8]
+  const bw = (w - 6) / hs.length
   return (
-    <g transform={`translate(${cx - 12 * s} ${cy - 12 * s}) scale(${s})`}>
-      <path
-        d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"
-        className="stroke-border-light"
-        strokeWidth="1.4"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <circle cx="12" cy="7" r="4" className="fill-bg stroke-border-light" strokeWidth="1.4" />
+    <>
+      <line x1={x + 3} y1={base} x2={x + w - 3} y2={base} className='stroke-line' strokeWidth='0.55' />
+      {hs.map((f, i) => (
+        <line
+          key={`br${i}`}
+          x1={x + 3 + i * bw + bw / 2}
+          y1={base}
+          x2={x + 3 + i * bw + bw / 2}
+          y2={base - (h - 8) * f}
+          className='stroke-line'
+          strokeWidth={bw - 1.2}
+        />
+      ))}
+    </>
+  )
+}
+
+/** A row of toggle/status dots. */
+function dots({ x, y, w, h }: Rect): ReactNode {
+  const cy = y + h / 2
+  return (
+    <>
+      {[0.2, 0.4, 0.6, 0.8].map(f => (
+        <circle key={`dt${f}`} cx={x + w * f} cy={cy} r='1.3' className='fill-bg stroke-line' strokeWidth='0.55' />
+      ))}
+    </>
+  )
+}
+
+/** Stacked data-row lines, count + widths adapting to the tile height. */
+function textRows({ x, y, w, h }: Rect): ReactNode {
+  const n = Math.max(2, Math.min(6, Math.floor((h - 3) / 4)))
+  const widths = [0.9, 0.6, 0.85, 0.5, 0.78, 0.45]
+  const gap = (h - 7) / n
+  return (
+    <>
+      {Array.from({ length: n }, (_, i) => (
+        <line
+          key={`tx${i}`}
+          x1={x + 3}
+          y1={y + 5 + i * gap}
+          x2={x + 3 + (w - 6) * widths[i % widths.length]}
+          y2={y + 5 + i * gap}
+          className='stroke-line'
+          strokeWidth='0.7'
+          strokeLinecap='round'
+        />
+      ))}
+    </>
+  )
+}
+
+const DECO = { hatch, bars, dots, text: textRows }
+
+// ── The generic stack: front dashboard (with content) sits on the right of the
+//    cluster; the deck recedes up and to the left so their title bars peek out. ──
+const FRONT: Rect = { x: 30, y: 38, w: 74, h: 84 }
+const BEHIND: Rect[] = [
+  { x: 14, y: 24, w: 74, h: 84 },
+  { x: 22, y: 31, w: 74, h: 84 },
+]
+// Clutter is authored for a front at x=14; shift it to match FRONT's position.
+const CLUTTER_DX = FRONT.x - 14
+
+// ── Your app: a clean sidebar + one insight widget. ──
+const RIGHT_WIN: Rect = { x: 184, y: 38, w: 76, h: 84 }
+const RAIL: Rect = { x: 190, y: 53, w: 14, h: 58 }
+const NAV: Rect[] = [
+  { x: 194, y: 57, w: 8, h: 6 }, // active (accent)
+  { x: 194, y: 67, w: 8, h: 6 },
+  { x: 194, y: 77, w: 8, h: 6 },
+  { x: 194, y: 87, w: 8, h: 6 },
+]
+const HEADER: Rect = { x: 210, y: 53, w: 44, h: 7 }
+const WIDGET: Rect = { x: 210, y: 62, w: 44, h: 30 } // clean insight widget
+const FOOTER: Rect = { x: 210, y: 97, w: 44, h: 7 }
+
+/** App window chrome: rounded frame + title bar + three dots. Thin borders. */
+function AppWindow({ x, y, w, h }: Rect) {
+  return (
+    <g>
+      <rect x={x} y={y} width={w} height={h} rx='3' className='fill-bg-card stroke-line' strokeWidth='1' />
+      <line x1={x} y1={y + 11} x2={x + w} y2={y + 11} className='stroke-line' strokeWidth='0.7' />
+      {[x + 8, x + 13, x + 18].map(dx => (
+        <circle key={`wd${dx}`} cx={dx} cy={y + 5.5} r='1.3' className='fill-bg stroke-line' strokeWidth='0.6' />
+      ))}
     </g>
   )
 }
 
 export function HeroGraphic({ className }: { className?: string }) {
-  const { ref, inView } = useInView<SVGSVGElement>()
-  const [beat, setBeat] = useState(0)
-  const timer = useRef<ReturnType<typeof setTimeout>>(undefined)
-
-  useEffect(() => {
-    if (!inView) return
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      setBeat(2) // park on the resolved frame: user standing on the Portal
-      return
-    }
-    let b = 0
-    setBeat(0)
-    const step = () => {
-      timer.current = setTimeout(() => {
-        b = (b + 1) % CAPTIONS.length
-        setBeat(b)
-        step()
-      }, HOLDS[b])
-    }
-    step()
-    return () => clearTimeout(timer.current)
-  }, [inView])
-
-  const anim = (opacity: number, extra?: CSSProperties): CSSProperties => ({ opacity, ...extra })
-
   return (
-    <svg
-      ref={ref}
-      data-hero-story
-      viewBox="0 0 200 200"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden
-      className={className}
+    <BlueprintGraphic
+      viewBox='0 0 274 150'
+      drawDelayMs={3600}
+      className={`hero-compare ${className ?? ''}`}
     >
-      {/* ── Tethers: tools pull on the hub (the user, then the app) ── */}
-      {SCATTER.map((n, i) => {
-        const a = edge(n.x, n.y, CENTER.x, CENTER.y, 10)
-        const b = edge(CENTER.x, CENTER.y, n.x, n.y, USER.r)
-        return (
-          <line
-            key={`t${i}`}
-            className="hs-anim stroke-border-light"
-            x1={a.x}
-            y1={a.y}
-            x2={b.x}
-            y2={b.y}
-            strokeWidth="1"
-            strokeLinecap="round"
-            style={anim(OP.tethers[beat])}
-          />
-        )
-      })}
+      {/* ── Titles ── */}
+      <text x='62' y='18' textAnchor='middle' className='fill-text-muted font-mono' fontSize='6.5' letterSpacing='0.5'>
+        Built for everyone
+      </text>
+      <text x='222' y='18' textAnchor='middle' className='fill-accent font-mono' fontSize='6.5' letterSpacing='0.5'>
+        Built for you
+      </text>
 
-      {/* ── Scattered SaaS logos → collapse into the Portal at beat 2 ── */}
-      {SCATTER.map((n, i) => {
-        const Logo = LOGOS[i]
-        const collapsed = beat >= 2
-        const cx = collapsed ? CENTER.x : n.x
-        const cy = collapsed ? CENTER.y : n.y
-        return (
-          <g
-            key={`l${i}`}
-            className="hs-anim text-text-muted"
-            style={anim(OP.logos[beat], { transform: `translate(${cx - LOGO_O}px, ${cy - LOGO_O}px)` })}
-          >
-            <g transform={`scale(${LOGO_S})`}>
-              <Logo />
-            </g>
-          </g>
-        )
-      })}
-
-      {/* ── The PTS Portal platform (beats 2+) — what the user stands on ── */}
-      <g className="hs-anim" style={anim(OP.portal[beat], { transform: `translateY(${beat >= 2 ? 0 : 6}px)` })}>
-        <rect x="56" y="63" width="88" height="53" rx="2" className="fill-bg stroke-border-light" strokeWidth="1.75" />
-        <g className="stroke-accent" strokeWidth="1.75" fill="none" strokeLinecap="round">
-          <path d="M56 71 V63 H64" />
-          <path d="M136 63 H144 V71" />
-          <path d="M56 108 V116 H64" />
-          <path d="M136 116 H144 V108" />
+      {/* ── Generic stack: dashboards come up one by one ── */}
+      <g className='cmp-in' style={cmp(0)}>
+        <AppWindow {...BEHIND[0]} />
+      </g>
+      <g className='cmp-in' style={cmp(200)}>
+        <AppWindow {...BEHIND[1]} />
+      </g>
+      <g className='cmp-in' style={cmp(400)}>
+        <AppWindow {...FRONT} />
+        <g transform={`translate(${CLUTTER_DX} 0)`}>
+          {CLUTTER.map((t, idx) => {
+            const Deco = t.deco ? DECO[t.deco] : null
+            return (
+              <g key={`c${idx}`}>
+                <rect x={t.x} y={t.y} width={t.w} height={t.h} className='fill-bg-card stroke-line' strokeWidth='0.75' />
+                {Deco && Deco(t)}
+              </g>
+            )
+          })}
         </g>
-        <text x="100" y="110" textAnchor="middle" className="fill-accent font-mono" fontSize="8" letterSpacing="1">
-          PORTAL
-        </text>
       </g>
 
-      {/* ── PTS accent core (beats 1+): the discovery, then the platform's heart ── */}
-      <g className="hs-anim" style={anim(OP.core[beat])}>
-        <rect x="93" y="87" width="14" height="14" className="fill-bg stroke-accent" strokeWidth="1.5" />
-        <rect x="97.5" y="91.5" width="5" height="5" className="hs-core fill-accent" />
-      </g>
+      {/* ── Your app: comes up last ── */}
+      <g className='cmp-in' style={cmp(940)}>
+        <AppWindow {...RIGHT_WIN} />
+        <rect x={RAIL.x} y={RAIL.y} width={RAIL.w} height={RAIL.h} rx='2' className='fill-bg-card stroke-line' strokeWidth='0.8' />
+        {NAV.map((n, i) => (
+          <rect
+            key={`nav${i}`}
+            x={n.x}
+            y={n.y}
+            width={n.w}
+            height={n.h}
+            rx='1'
+            className={i === 0 ? 'fill-accent' : 'fill-bg-card stroke-line'}
+            strokeWidth={i === 0 ? undefined : '0.7'}
+          />
+        ))}
+        <rect x={HEADER.x} y={HEADER.y} width={HEADER.w} height={HEADER.h} rx='1' className='fill-bg-card stroke-line' strokeWidth='0.8' />
+        <rect x={FOOTER.x} y={FOOTER.y} width={FOOTER.w} height={FOOTER.h} rx='1' className='fill-bg-card stroke-line' strokeWidth='0.8' />
 
-      {/* ── The user: centred hub during overload, then rises to stand on the
-             Portal platform (the hub ring fades once they're standing) ── */}
-      <g className="hs-anim" style={{ transform: `translateY(${beat === 0 ? USER_DROP : 0}px)` }}>
+        {/* Insight widget — hollow frame, a couple of bars, a rising accent
+            trend and one live node (mirrors ChartGraphic). */}
+        <rect x={WIDGET.x} y={WIDGET.y} width={WIDGET.w} height={WIDGET.h} rx='1.5' className='fill-bg-card stroke-line' strokeWidth='0.9' />
+        <line x1='214' y1='88' x2='250' y2='88' className='stroke-line' strokeWidth='0.6' strokeLinecap='round' />
+        <rect x='216' y='79' width='6' height='9' className='fill-bg-card stroke-line' strokeWidth='0.7' />
+        <rect x='225' y='73' width='6' height='15' className='fill-bg-card stroke-line' strokeWidth='0.7' />
+        <rect x='234' y='68' width='6' height='20' className='fill-bg-card stroke-line' strokeWidth='0.7' />
+        <polyline points='217,79 228,72 237,67 248,63' className='stroke-accent' strokeWidth='1.4' fill='none' strokeLinejoin='round' strokeLinecap='round' />
         <circle
-          cx={USER.x}
-          cy={USER.y}
-          r={USER.r}
-          className="hs-anim fill-bg stroke-border-light"
-          strokeWidth="1.5"
-          style={anim(OP.ring[beat])}
+          cx='248'
+          cy='63'
+          r='2.4'
+          className='cmp-live fill-accent'
+          style={{ ['--cmp-live-delay']: '1700ms' } as CSSProperties}
         />
-        <Person cx={USER.x} cy={USER.y} s={1.15} />
       </g>
 
-      {/* ── Strategy thought-bubbles (beat 3): ideas rising from the user ── */}
-      <g className="hs-anim" style={anim(OP.thoughts[beat], { transform: `translateY(${beat === 3 ? 0 : 12}px)` })}>
-        {/* thought trail rising from the user's head */}
-        <circle cx="100" cy="36" r="1.4" className="fill-border-light" />
-        <circle cx="100" cy="30" r="2.1" className="fill-bg stroke-border-light" strokeWidth="1.2" />
-        {/* bubbles */}
-        <circle cx="66" cy="24" r="8" className="fill-bg stroke-border-light" strokeWidth="1.3" />
-        <circle cx="100" cy="14" r="8" className="fill-bg stroke-border-light" strokeWidth="1.3" />
-        <circle cx="134" cy="24" r="8" className="fill-bg stroke-border-light" strokeWidth="1.3" />
-        {/* growth trend */}
-        <g className="stroke-accent" strokeWidth="1.5" fill="none" strokeLinejoin="round" strokeLinecap="round">
-          <polyline points="59,28 64,23 68,25 73,18" />
-          <path d="M69.5 18 h3.5 v3.5" />
-        </g>
-        {/* lightbulb */}
-        <g className="stroke-accent" strokeWidth="1.5" fill="none" strokeLinecap="round">
-          <circle cx="100" cy="11" r="4" />
-          <line x1="98" y1="17" x2="102" y2="17" />
-          <line x1="98.7" y1="19" x2="101.3" y2="19" />
-        </g>
-        {/* target */}
-        <g className="stroke-accent" strokeWidth="1.5" fill="none">
-          <circle cx="134" cy="24" r="4.5" />
-          <circle cx="134" cy="24" r="2" className="fill-accent" stroke="none" />
-        </g>
-      </g>
-
-      {/* ── Journey timeline: track + filling progress + step nodes ── */}
-      <line x1="60" y1="180" x2="140" y2="180" className="stroke-border-light" strokeWidth="1.5" strokeLinecap="round" />
-      <line
-        x1="60"
-        y1="180"
-        x2="140"
-        y2="180"
-        className="hs-anim stroke-accent"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        style={{ transform: `scaleX(${beat / (CAPTIONS.length - 1)})`, transformBox: 'fill-box', transformOrigin: 'left' }}
-      />
-      {CAPTIONS.map((_, i) => {
-        const on = i <= beat
-        return (
-          <circle
-            key={`step${i}`}
-            className={on ? 'hs-anim fill-accent' : 'hs-anim fill-bg stroke-border-light'}
-            cx={60 + (i * 80) / (CAPTIONS.length - 1)}
-            cy="180"
-            r={i === beat ? 3 : 2.2}
-            strokeWidth={on ? undefined : 1.3}
-          />
-        )
-      })}
-
-      {/* ── Caption ── */}
-      {CAPTIONS.map((c, i) => (
-        <text
-          key={c}
-          className="hs-anim fill-text-muted font-mono"
-          x="100"
-          y="196"
-          textAnchor="middle"
-          fontSize="7.5"
-          letterSpacing="1.5"
-          style={anim(beat === i ? 1 : 0)}
-        >
-          {c}
+      {/* ── Transformation arrow, annotated with the transition. Rendered last
+             so its labels always sit above the windows. ── */}
+      <g className='cmp-in' style={cmp(680)}>
+        <text x='144' y='73' textAnchor='middle' className='fill-text-muted font-mono' fontSize='6' letterSpacing='0.5'>
+          CONSOLIDATE
         </text>
-      ))}
-    </svg>
+        <g className='stroke-line' strokeWidth='1.2' strokeLinecap='round' strokeLinejoin='round' fill='none'>
+          <line x1='132' y1='80' x2='156' y2='80' />
+          <path d='M151 76 L156 80 L151 84' />
+        </g>
+        <text x='144' y='96' textAnchor='middle' className='fill-accent font-mono' fontSize='6' letterSpacing='0.5'>
+          CUSTOM FIT
+        </text>
+      </g>
+    </BlueprintGraphic>
   )
 }

--- a/src/components/graphics/hero-graphic.tsx
+++ b/src/components/graphics/hero-graphic.tsx
@@ -1,0 +1,256 @@
+'use client'
+
+import { useEffect, useRef, useState, type CSSProperties } from 'react'
+import { useInView } from './blueprint-graphic'
+import { AsanaLogo, MondayLogo, SlackLogo, TrelloLogo, NotionLogo } from './saas-logos'
+
+/**
+ * Hero signature piece — a looping four-beat story that plays after the hero
+ * intro and repeats, leaning into the "Place to Stand" metaphor: the PTS Portal
+ * is the platform, and the user ends up standing on top of it.
+ *   0 TOOL OVERLOAD  — the user, centred, tethered to scattered SaaS tools.
+ *   1 MEET PTS       — the tools dim; the lime PTS core appears where the user was,
+ *                      and the user rises to stand above it (first accent).
+ *   2 YOUR DASHBOARD — the tools collapse into the PTS Portal, now a solid platform
+ *                      the user stands on.
+ *   3 THINK BIGGER   — strategy ideas rise from the user, up off the top.
+ *
+ * Self-contained: a JS beat sequencer toggles `beat`; per-element opacity/transform
+ * is set inline and CSS (.hs-anim in globals.css) tweens it. Reuses `useInView`
+ * for the in-view gate + reduced-motion detection; under reduced motion it parks on
+ * beat 2 (user standing on the Portal) with no timer.
+ */
+
+const CAPTIONS = ['TOOL OVERLOAD', 'MEET PTS', 'YOUR DASHBOARD', 'THINK BIGGER']
+const HOLDS = [3200, 2600, 3000, 3400] // ms held on each beat
+
+// Opacity of each element group per beat [0..3].
+const OP = {
+  logos: [1, 0.4, 0, 0],
+  tethers: [0.7, 0.35, 0, 0],
+  ring: [1, 1, 0, 0], // the hub ring — only while the user is the centre
+  core: [0, 1, 1, 1],
+  portal: [0, 0, 1, 1],
+  thoughts: [0, 0, 0, 1],
+}
+
+const CENTER = { x: 100, y: 94 } // the hub: the user (beat 0), then the Portal core
+const USER = { x: 100, y: 52, r: 17 } // the user's resting spot — standing on top
+const USER_DROP = CENTER.y - USER.y // translateY that drops the user to CENTER for beat 0
+const LOGO_S = 0.7
+const LOGO_O = 12 * LOGO_S // half of the 24-grid glyph, scaled
+
+// Tools orbit the hub.
+const SCATTER = [
+  { x: 100, y: 40 },
+  { x: 151, y: 77 },
+  { x: 132, y: 138 },
+  { x: 68, y: 138 },
+  { x: 49, y: 77 },
+]
+const LOGOS = [AsanaLogo, MondayLogo, SlackLogo, TrelloLogo, NotionLogo]
+
+/** Point on a circle of radius r (centre cx,cy) in the direction of (px,py). */
+function edge(cx: number, cy: number, px: number, py: number, r: number) {
+  const dx = px - cx
+  const dy = py - cy
+  const len = Math.hypot(dx, dy) || 1
+  return { x: cx + (dx / len) * r, y: cy + (dy / len) * r }
+}
+
+/** A person, from lucide's `User` bust glyph, placed + scaled at (cx,cy). */
+function Person({ cx, cy, s }: { cx: number; cy: number; s: number }) {
+  return (
+    <g transform={`translate(${cx - 12 * s} ${cy - 12 * s}) scale(${s})`}>
+      <path
+        d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"
+        className="stroke-border-light"
+        strokeWidth="1.4"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="12" cy="7" r="4" className="fill-bg stroke-border-light" strokeWidth="1.4" />
+    </g>
+  )
+}
+
+export function HeroGraphic({ className }: { className?: string }) {
+  const { ref, inView } = useInView<SVGSVGElement>()
+  const [beat, setBeat] = useState(0)
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  useEffect(() => {
+    if (!inView) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setBeat(2) // park on the resolved frame: user standing on the Portal
+      return
+    }
+    let b = 0
+    setBeat(0)
+    const step = () => {
+      timer.current = setTimeout(() => {
+        b = (b + 1) % CAPTIONS.length
+        setBeat(b)
+        step()
+      }, HOLDS[b])
+    }
+    step()
+    return () => clearTimeout(timer.current)
+  }, [inView])
+
+  const anim = (opacity: number, extra?: CSSProperties): CSSProperties => ({ opacity, ...extra })
+
+  return (
+    <svg
+      ref={ref}
+      data-hero-story
+      viewBox="0 0 200 200"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+      className={className}
+    >
+      {/* ── Tethers: tools pull on the hub (the user, then the app) ── */}
+      {SCATTER.map((n, i) => {
+        const a = edge(n.x, n.y, CENTER.x, CENTER.y, 10)
+        const b = edge(CENTER.x, CENTER.y, n.x, n.y, USER.r)
+        return (
+          <line
+            key={`t${i}`}
+            className="hs-anim stroke-border-light"
+            x1={a.x}
+            y1={a.y}
+            x2={b.x}
+            y2={b.y}
+            strokeWidth="1"
+            strokeLinecap="round"
+            style={anim(OP.tethers[beat])}
+          />
+        )
+      })}
+
+      {/* ── Scattered SaaS logos → collapse into the Portal at beat 2 ── */}
+      {SCATTER.map((n, i) => {
+        const Logo = LOGOS[i]
+        const collapsed = beat >= 2
+        const cx = collapsed ? CENTER.x : n.x
+        const cy = collapsed ? CENTER.y : n.y
+        return (
+          <g
+            key={`l${i}`}
+            className="hs-anim text-text-muted"
+            style={anim(OP.logos[beat], { transform: `translate(${cx - LOGO_O}px, ${cy - LOGO_O}px)` })}
+          >
+            <g transform={`scale(${LOGO_S})`}>
+              <Logo />
+            </g>
+          </g>
+        )
+      })}
+
+      {/* ── The PTS Portal platform (beats 2+) — what the user stands on ── */}
+      <g className="hs-anim" style={anim(OP.portal[beat], { transform: `translateY(${beat >= 2 ? 0 : 6}px)` })}>
+        <rect x="56" y="63" width="88" height="53" rx="2" className="fill-bg stroke-border-light" strokeWidth="1.75" />
+        <g className="stroke-accent" strokeWidth="1.75" fill="none" strokeLinecap="round">
+          <path d="M56 71 V63 H64" />
+          <path d="M136 63 H144 V71" />
+          <path d="M56 108 V116 H64" />
+          <path d="M136 116 H144 V108" />
+        </g>
+        <text x="100" y="110" textAnchor="middle" className="fill-accent font-mono" fontSize="8" letterSpacing="1">
+          PORTAL
+        </text>
+      </g>
+
+      {/* ── PTS accent core (beats 1+): the discovery, then the platform's heart ── */}
+      <g className="hs-anim" style={anim(OP.core[beat])}>
+        <rect x="93" y="87" width="14" height="14" className="fill-bg stroke-accent" strokeWidth="1.5" />
+        <rect x="97.5" y="91.5" width="5" height="5" className="hs-core fill-accent" />
+      </g>
+
+      {/* ── The user: centred hub during overload, then rises to stand on the
+             Portal platform (the hub ring fades once they're standing) ── */}
+      <g className="hs-anim" style={{ transform: `translateY(${beat === 0 ? USER_DROP : 0}px)` }}>
+        <circle
+          cx={USER.x}
+          cy={USER.y}
+          r={USER.r}
+          className="hs-anim fill-bg stroke-border-light"
+          strokeWidth="1.5"
+          style={anim(OP.ring[beat])}
+        />
+        <Person cx={USER.x} cy={USER.y} s={1.15} />
+      </g>
+
+      {/* ── Strategy thought-bubbles (beat 3): ideas rising from the user ── */}
+      <g className="hs-anim" style={anim(OP.thoughts[beat], { transform: `translateY(${beat === 3 ? 0 : 12}px)` })}>
+        {/* thought trail rising from the user's head */}
+        <circle cx="100" cy="36" r="1.4" className="fill-border-light" />
+        <circle cx="100" cy="30" r="2.1" className="fill-bg stroke-border-light" strokeWidth="1.2" />
+        {/* bubbles */}
+        <circle cx="66" cy="24" r="8" className="fill-bg stroke-border-light" strokeWidth="1.3" />
+        <circle cx="100" cy="14" r="8" className="fill-bg stroke-border-light" strokeWidth="1.3" />
+        <circle cx="134" cy="24" r="8" className="fill-bg stroke-border-light" strokeWidth="1.3" />
+        {/* growth trend */}
+        <g className="stroke-accent" strokeWidth="1.5" fill="none" strokeLinejoin="round" strokeLinecap="round">
+          <polyline points="59,28 64,23 68,25 73,18" />
+          <path d="M69.5 18 h3.5 v3.5" />
+        </g>
+        {/* lightbulb */}
+        <g className="stroke-accent" strokeWidth="1.5" fill="none" strokeLinecap="round">
+          <circle cx="100" cy="11" r="4" />
+          <line x1="98" y1="17" x2="102" y2="17" />
+          <line x1="98.7" y1="19" x2="101.3" y2="19" />
+        </g>
+        {/* target */}
+        <g className="stroke-accent" strokeWidth="1.5" fill="none">
+          <circle cx="134" cy="24" r="4.5" />
+          <circle cx="134" cy="24" r="2" className="fill-accent" stroke="none" />
+        </g>
+      </g>
+
+      {/* ── Journey timeline: track + filling progress + step nodes ── */}
+      <line x1="60" y1="180" x2="140" y2="180" className="stroke-border-light" strokeWidth="1.5" strokeLinecap="round" />
+      <line
+        x1="60"
+        y1="180"
+        x2="140"
+        y2="180"
+        className="hs-anim stroke-accent"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        style={{ transform: `scaleX(${beat / (CAPTIONS.length - 1)})`, transformBox: 'fill-box', transformOrigin: 'left' }}
+      />
+      {CAPTIONS.map((_, i) => {
+        const on = i <= beat
+        return (
+          <circle
+            key={`step${i}`}
+            className={on ? 'hs-anim fill-accent' : 'hs-anim fill-bg stroke-border-light'}
+            cx={60 + (i * 80) / (CAPTIONS.length - 1)}
+            cy="180"
+            r={i === beat ? 3 : 2.2}
+            strokeWidth={on ? undefined : 1.3}
+          />
+        )
+      })}
+
+      {/* ── Caption ── */}
+      {CAPTIONS.map((c, i) => (
+        <text
+          key={c}
+          className="hs-anim fill-text-muted font-mono"
+          x="100"
+          y="196"
+          textAnchor="middle"
+          fontSize="7.5"
+          letterSpacing="1.5"
+          style={anim(beat === i ? 1 : 0)}
+        >
+          {c}
+        </text>
+      ))}
+    </svg>
+  )
+}

--- a/src/components/graphics/home-graphics.tsx
+++ b/src/components/graphics/home-graphics.tsx
@@ -1,0 +1,367 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+import { BlueprintGraphic } from './blueprint-graphic'
+
+/**
+ * Animated blueprint schematics for the homepage sections. Same visual language
+ * as process-graphics.tsx (100x100 viewBox, thin stroke-line lines, one
+ * accent highlight, hollow nodes on fill-bg-card) but wrapped in <BlueprintGraphic> so
+ * each draws itself in on scroll and settles into a subtle ongoing loop.
+ *
+ * Element roles (see globals.css): .bp-line = structural stroke (draws in,
+ * staggered by --draw-i), .bp-node = the accent highlight (snaps in),
+ * .bp-fx = a loop-dedicated element (fades in, then its loop takes over).
+ */
+
+type GraphicProps = { className?: string }
+
+/** Draw-order helper: sets the per-element stagger index. */
+const di = (i: number) => ({ ['--draw-i']: i }) as CSSProperties
+
+// ─── Pillars — the customer-value story ───
+
+/** No Per-Seat Pricing — a flat cost line while user seats multiply beneath it. */
+export function SeatsGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-pulse' className={className}>
+      {/* Flat cost line — stays level no matter how many seats are added */}
+      <line x1="16" y1="30" x2="84" y2="30" className="bp-line stroke-line" strokeWidth="2" strokeLinecap="round" style={di(0)} />
+      <line x1="16" y1="26" x2="16" y2="34" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(1)} />
+      <line x1="84" y1="26" x2="84" y2="34" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(1)} />
+      {/* Seat baseline */}
+      <line x1="16" y1="80" x2="84" y2="80" className="bp-line stroke-line" strokeWidth="1.5" strokeDasharray="3 4" strokeLinecap="round" style={di(2)} />
+      {/* User seats sitting on the baseline */}
+      {[26, 42, 58].map((x, i) => (
+        <g key={x}>
+          <circle cx={x} cy="60" r="4" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(3 + i)} />
+          <path d={`M${x - 5} 80 q0 -8 5 -8 q5 0 5 8`} className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(3 + i)} />
+        </g>
+      ))}
+      {/* The "+1, free" seat — accent, and it pulses */}
+      <circle cx="74" cy="60" r="4.5" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Centralized Business Data — scattered sources feeding one accent hub. */
+export function CentralizedDataGraphic({ className }: GraphicProps) {
+  const sources: [number, number][] = [
+    [22, 24],
+    [78, 24],
+    [20, 72],
+    [80, 72],
+  ]
+  return (
+    <BlueprintGraphic loop='bp-loop-travel' className={className}>
+      {/* Spokes */}
+      {sources.map(([x, y], i) => (
+        <line key={`s${x}${y}`} x1={x} y1={y} x2="50" y2="50" className="bp-line stroke-line" strokeWidth="1.5" style={di(i)} />
+      ))}
+      {/* Source nodes */}
+      {sources.map(([x, y], i) => (
+        <circle key={`n${x}${y}`} cx={x} cy={y} r="5" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(1 + i)} />
+      ))}
+      {/* Inbound flow along each spoke */}
+      {sources.map(([x, y]) => (
+        <line key={`f${x}${y}`} x1={x} y1={y} x2="50" y2="50" className="bp-fx bp-flow stroke-accent" strokeWidth="1.5" strokeDasharray="2 7" strokeLinecap="round" />
+      ))}
+      {/* Central hub — accent */}
+      <circle cx="50" cy="50" r="8" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** No SaaS Feature Bloat — many modules funnel down to one you actually use. */
+export function NoBloatGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-pulse' className={className}>
+      {/* Incoming modules */}
+      {[22, 39, 56, 73].map((x, i) => (
+        <rect key={x} x={x - 5} y="16" width="10" height="10" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(i)} />
+      ))}
+      {/* Funnel */}
+      <path d="M18 34 L45 56 L45 66" className="bp-line stroke-line" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" style={di(4)} />
+      <path d="M82 34 L55 56 L55 66" className="bp-line stroke-line" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" style={di(4)} />
+      <line x1="45" y1="70" x2="55" y2="70" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(5)} />
+      {/* The one module you keep — accent */}
+      <rect x="44" y="76" width="12" height="12" rx="1" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+// ─── Services — schematic versions of the accordion icons ───
+
+/** Software Development — a code window with a blinking accent cursor. */
+function CodeGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-pulse' className={className}>
+      <rect x="14" y="22" width="72" height="56" rx="2" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(0)} />
+      <line x1="14" y1="36" x2="86" y2="36" className="bp-line stroke-line" strokeWidth="1.5" style={di(1)} />
+      <line x1="24" y1="48" x2="58" y2="48" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(2)} />
+      <line x1="24" y1="58" x2="48" y2="58" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(3)} />
+      <line x1="24" y1="68" x2="52" y2="68" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(4)} />
+      <rect x="60" y="54" width="6" height="9" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Workflow Systems — a branch splitting off a mainline, with flow along it. */
+function BranchGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-travel' className={className}>
+      <line x1="34" y1="20" x2="34" y2="80" className="bp-line stroke-line" strokeWidth="2" strokeLinecap="round" style={di(0)} />
+      <path d="M34 50 q0 16 16 16 h6" className="bp-line stroke-line" strokeWidth="1.5" fill="none" strokeLinecap="round" style={di(1)} />
+      <line x1="34" y1="20" x2="34" y2="80" className="bp-fx bp-flow stroke-accent" strokeWidth="2" strokeDasharray="2 8" strokeLinecap="round" />
+      <circle cx="34" cy="30" r="5" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(2)} />
+      <circle cx="34" cy="70" r="5" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(3)} />
+      <circle cx="62" cy="66" r="5.5" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Data Intelligence — bars with a rising accent trend line. */
+function ChartGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-pulse' className={className}>
+      <line x1="16" y1="82" x2="86" y2="82" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(0)} />
+      <rect x="22" y="62" width="12" height="20" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(1)} />
+      <rect x="42" y="50" width="12" height="32" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(2)} />
+      <rect x="62" y="34" width="12" height="48" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(3)} />
+      <polyline points="22,60 40,48 60,40 74,24" className="bp-line stroke-accent" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" style={di(4)} />
+      <circle cx="74" cy="24" r="4.5" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Strategic Advisory — a compass with a slowly rotating bearing needle. */
+function CompassGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-gear' className={className}>
+      <circle cx="50" cy="50" r="30" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(0)} />
+      <line x1="50" y1="18" x2="50" y2="25" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(1)} />
+      <line x1="50" y1="75" x2="50" y2="82" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(1)} />
+      <line x1="18" y1="50" x2="25" y2="50" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(1)} />
+      <line x1="75" y1="50" x2="82" y2="50" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(1)} />
+      {/* Bearing needle — fades in, then rotates in place */}
+      <g className="bp-fx bp-gear">
+        <path d="M36 64 L50 50 L64 36" className="stroke-accent" strokeWidth="2" fill="none" strokeLinejoin="round" strokeLinecap="round" />
+      </g>
+      <circle cx="50" cy="50" r="3.5" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Managed Services — a server stack with a running cog and a status light. */
+function ServerGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-gear bp-loop-pulse' className={className}>
+      {[24, 44, 64].map((y, i) => (
+        <g key={y}>
+          <rect x="16" y={y} width="46" height="14" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(i)} />
+          <line x1="22" y1={y + 7} x2="30" y2={y + 7} className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(i)} />
+        </g>
+      ))}
+      {/* Cog — fades in, then spins */}
+      <g className="bp-fx bp-gear">
+        <circle cx="76" cy="38" r="8" className="stroke-accent" strokeWidth="1.5" fill="none" />
+        <g className="stroke-accent" strokeWidth="1.5" strokeLinecap="round">
+          <line x1="76" y1="26" x2="76" y2="30" />
+          <line x1="76" y1="46" x2="76" y2="50" />
+          <line x1="64" y1="38" x2="68" y2="38" />
+          <line x1="84" y1="38" x2="88" y2="38" />
+        </g>
+      </g>
+      {/* Status light — accent, pulses */}
+      <circle cx="54" cy="31" r="3" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Icon-key → schematic, mirroring serviceIcons in src/lib/service-icons.ts. */
+export const serviceGraphics: Record<
+  string,
+  (props: GraphicProps) => React.ReactElement
+> = {
+  Code2: CodeGraphic,
+  GitBranch: BranchGraphic,
+  BarChart3: ChartGraphic,
+  Compass: CompassGraphic,
+  ServerCog: ServerGraphic,
+}
+
+// ─── Manifesto — who we are ───
+
+/** Senior Builders — a drafting compass sweeping an accent arc. */
+export function DraftingGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-pulse' className={className}>
+      {/* Compass legs */}
+      <line x1="50" y1="20" x2="30" y2="78" className="bp-line stroke-line" strokeWidth="2" strokeLinecap="round" style={di(0)} />
+      <line x1="50" y1="20" x2="70" y2="78" className="bp-line stroke-line" strokeWidth="2" strokeLinecap="round" style={di(0)} />
+      <line x1="44" y1="37" x2="56" y2="37" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(1)} />
+      {/* The drawn arc */}
+      <path d="M30 78 A 34 34 0 0 0 70 78" className="bp-line stroke-line" strokeWidth="1.5" fill="none" strokeDasharray="3 4" strokeLinecap="round" style={di(2)} />
+      {/* Pivot — accent */}
+      <circle cx="50" cy="20" r="5" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** AI-Native — nodes wired into a running cog. */
+export function AiNativeGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-gear bp-loop-pulse' className={className}>
+      {/* Input nodes wired to the core */}
+      {[
+        [20, 28],
+        [20, 72],
+      ].map(([x, y], i) => (
+        <g key={x + '' + y}>
+          <line x1={x} y1={y} x2="44" y2="50" className="bp-line stroke-line" strokeWidth="1.5" style={di(i)} />
+          <circle cx={x} cy={y} r="4.5" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(i)} />
+        </g>
+      ))}
+      {/* Cog core — spins */}
+      <g className="bp-fx bp-gear">
+        <circle cx="60" cy="50" r="14" className="stroke-line" strokeWidth="1.5" fill="none" />
+        <g className="stroke-line" strokeWidth="1.5" strokeLinecap="round">
+          <line x1="60" y1="30" x2="60" y2="36" />
+          <line x1="60" y1="64" x2="60" y2="70" />
+          <line x1="40" y1="50" x2="46" y2="50" />
+          <line x1="74" y1="50" x2="80" y2="50" />
+          <line x1="46" y1="36" x2="50" y2="40" />
+          <line x1="70" y1="60" x2="74" y2="64" />
+        </g>
+      </g>
+      {/* Core — accent, pulses */}
+      <circle cx="60" cy="50" r="4" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Direct Access — one clean line between two nodes, with flow along it. */
+export function DirectAccessGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-travel' className={className}>
+      {/* The detour we skip */}
+      <path d="M26 50 q24 -34 48 0" className="bp-line stroke-line" strokeWidth="1.5" fill="none" strokeDasharray="3 5" strokeLinecap="round" style={di(0)} />
+      {/* The direct line */}
+      <line x1="26" y1="50" x2="74" y2="50" className="bp-line stroke-line" strokeWidth="2" strokeLinecap="round" style={di(1)} />
+      <line x1="26" y1="50" x2="74" y2="50" className="bp-fx bp-flow stroke-accent" strokeWidth="2" strokeDasharray="2 8" strokeLinecap="round" />
+      <circle cx="26" cy="50" r="6" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(2)} />
+      {/* You — accent endpoint */}
+      <circle cx="74" cy="50" r="6" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+// ─── Who We Work With ───
+
+/** Lean Mid-Market — an established building gaining an accent capability. */
+export function LeanMarketGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-scan' className={className}>
+      <rect x="30" y="34" width="40" height="48" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(0)} />
+      {[
+        [38, 44],
+        [54, 44],
+        [38, 60],
+        [54, 60],
+      ].map(([x, y]) => (
+        <rect key={x + '' + y} x={x} y={y} width="8" height="8" className="bp-line stroke-line" strokeWidth="1.5" style={di(1)} />
+      ))}
+      <line x1="26" y1="82" x2="74" y2="82" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(2)} />
+      {/* Scan sweep */}
+      <line x1="30" y1="36" x2="70" y2="36" className="bp-fx bp-scan stroke-accent" strokeWidth="1.5" strokeLinecap="round" />
+      {/* Added capability — accent */}
+      <rect x="45" y="20" width="10" height="10" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Technical Founder — a terminal prompt with a blinking accent cursor. */
+export function FounderGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-pulse' className={className}>
+      <rect x="16" y="26" width="68" height="48" rx="2" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(0)} />
+      <line x1="16" y1="38" x2="84" y2="38" className="bp-line stroke-line" strokeWidth="1.5" style={di(1)} />
+      <path d="M26 50 l8 6 l-8 6" className="bp-line stroke-line" strokeWidth="2" fill="none" strokeLinejoin="round" strokeLinecap="round" style={di(2)} />
+      <line x1="40" y1="62" x2="58" y2="62" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(3)} />
+      <rect x="62" y="54" width="7" height="10" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Design-Led Team — an artboard with a bezier curve and accent control point. */
+export function DesignLedGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-travel' className={className}>
+      <rect x="18" y="20" width="64" height="60" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(0)} />
+      <path d="M28 68 C 40 30, 60 74, 72 34" className="bp-line stroke-line" strokeWidth="2" fill="none" strokeLinecap="round" style={di(1)} />
+      <path d="M28 68 C 40 30, 60 74, 72 34" className="bp-fx bp-flow stroke-accent" strokeWidth="2" fill="none" strokeDasharray="2 9" strokeLinecap="round" />
+      <line x1="28" y1="68" x2="40" y2="30" className="bp-line stroke-line" strokeWidth="1" strokeDasharray="3 3" style={di(2)} />
+      <circle cx="28" cy="68" r="3.5" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(3)} />
+      {/* Control point — accent */}
+      <circle cx="40" cy="30" r="4.5" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+// ─── Phases (How We Work) ───
+
+/** Prototype — an experiment flask with a bubbling accent core. */
+export function PrototypeGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-pulse' className={className}>
+      <line x1="40" y1="20" x2="60" y2="20" className="bp-line stroke-line" strokeWidth="2" strokeLinecap="round" style={di(0)} />
+      <path d="M43 21 V42 L31 70 Q31 78 39 78 H61 Q69 78 69 70 L57 42 V21" className="bp-line stroke-line" strokeWidth="2" fill="none" strokeLinejoin="round" strokeLinecap="round" style={di(1)} />
+      <line x1="34" y1="65" x2="66" y2="65" className="bp-line stroke-line" strokeWidth="1.5" strokeDasharray="3 3" style={di(2)} />
+      <circle cx="50" cy="61" r="5" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Refine — tuning sliders with one accent knob. */
+export function RefineGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-pulse' className={className}>
+      <line x1="20" y1="34" x2="80" y2="34" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(0)} />
+      <line x1="20" y1="50" x2="80" y2="50" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(1)} />
+      <line x1="20" y1="66" x2="80" y2="66" className="bp-line stroke-line" strokeWidth="1.5" strokeLinecap="round" style={di(2)} />
+      <circle cx="60" cy="34" r="5" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(0)} />
+      <circle cx="34" cy="66" r="5" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(2)} />
+      {/* The knob we tune — accent */}
+      <circle cx="44" cy="50" r="5.5" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** Scale — a stack of layers with an accent arrow rising off it. */
+export function ScaleGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-pulse' className={className}>
+      <rect x="26" y="60" width="40" height="11" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(0)} />
+      <rect x="26" y="46" width="40" height="11" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(1)} />
+      <rect x="26" y="32" width="40" height="11" className="bp-line fill-bg-card stroke-line" strokeWidth="1.5" style={di(2)} />
+      <line x1="76" y1="46" x2="76" y2="24" className="bp-line stroke-accent" strokeWidth="2" strokeLinecap="round" style={di(3)} />
+      <path d="M71 29 l5 -5 l5 5" className="bp-line stroke-accent" strokeWidth="2" fill="none" strokeLinejoin="round" strokeLinecap="round" style={di(3)} />
+      <circle cx="76" cy="46" r="3.5" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}
+
+/** R&D — an atom: orbits slowly turning around an accent nucleus. */
+export function RnDGraphic({ className }: GraphicProps) {
+  return (
+    <BlueprintGraphic loop='bp-loop-gear' className={className}>
+      <g className="bp-fx bp-gear">
+        <ellipse cx="50" cy="50" rx="30" ry="12" className="stroke-line" strokeWidth="1.5" fill="none" />
+        <ellipse cx="50" cy="50" rx="30" ry="12" className="stroke-line" strokeWidth="1.5" fill="none" transform="rotate(60 50 50)" />
+        <ellipse cx="50" cy="50" rx="30" ry="12" className="stroke-line" strokeWidth="1.5" fill="none" transform="rotate(120 50 50)" />
+      </g>
+      {/* Nucleus — accent */}
+      <circle cx="50" cy="50" r="5.5" className="bp-node fill-accent" />
+    </BlueprintGraphic>
+  )
+}

--- a/src/components/graphics/saas-logos.tsx
+++ b/src/components/graphics/saas-logos.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement } from 'react'
+
+/**
+ * Simplified, monochrome SaaS logo marks for the hero's "sprawl" side. Authored
+ * on a 24x24 grid using currentColor, so a parent group sets the (muted grey)
+ * colour and a transform scales them into the scattered field. Recognisable by
+ * silhouette; deliberately not brand-coloured, to stay within the site palette
+ * and let the single accent app read as the resolution.
+ */
+
+export function AsanaLogo(): ReactElement {
+  return (
+    <g fill="currentColor">
+      <circle cx="12" cy="6" r="3.4" />
+      <circle cx="6.2" cy="15.5" r="3.4" />
+      <circle cx="17.8" cy="15.5" r="3.4" />
+    </g>
+  )
+}
+
+export function MondayLogo(): ReactElement {
+  return (
+    <g fill="currentColor">
+      <rect x="4.5" y="5" width="3.5" height="14" rx="1.75" />
+      <rect x="10.25" y="5" width="3.5" height="14" rx="1.75" />
+      <rect x="16" y="5" width="3.5" height="14" rx="1.75" />
+    </g>
+  )
+}
+
+export function SlackLogo(): ReactElement {
+  return (
+    <g stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
+      <line x1="9" y1="3.5" x2="7.5" y2="20.5" />
+      <line x1="16.5" y1="3.5" x2="15" y2="20.5" />
+      <line x1="3.5" y1="9" x2="20.5" y2="7.5" />
+      <line x1="3.5" y1="16.5" x2="20.5" y2="15" />
+    </g>
+  )
+}
+
+export function TrelloLogo(): ReactElement {
+  return (
+    <g>
+      <rect x="3" y="3" width="18" height="18" rx="3" fill="none" stroke="currentColor" strokeWidth="2" />
+      <rect x="6.5" y="6.5" width="4" height="11" rx="1" fill="currentColor" />
+      <rect x="13.5" y="6.5" width="4" height="7.5" rx="1" fill="currentColor" />
+    </g>
+  )
+}
+
+export function NotionLogo(): ReactElement {
+  return (
+    <g>
+      <rect x="3" y="3" width="18" height="18" rx="3" fill="none" stroke="currentColor" strokeWidth="2" />
+      <path d="M8.5 16.5 V8 l7 8.5 V8" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </g>
+  )
+}
+
+export function SheetsLogo(): ReactElement {
+  return (
+    <g>
+      <rect x="4" y="4" width="16" height="16" rx="2" fill="none" stroke="currentColor" strokeWidth="2" />
+      <line x1="4" y1="10.3" x2="20" y2="10.3" stroke="currentColor" strokeWidth="1.6" />
+      <line x1="4" y1="15" x2="20" y2="15" stroke="currentColor" strokeWidth="1.6" />
+      <line x1="12" y1="4" x2="12" y2="20" stroke="currentColor" strokeWidth="1.6" />
+    </g>
+  )
+}

--- a/src/components/icons/vendor-icons.tsx
+++ b/src/components/icons/vendor-icons.tsx
@@ -114,6 +114,22 @@ function LMStudioIcon(props: SVGProps<SVGSVGElement>) {
   )
 }
 
+function GitIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path d="M23.546 10.93 13.067.452c-.604-.603-1.582-.603-2.188 0L8.708 2.627l2.76 2.76c.645-.215 1.379-.07 1.889.441.516.515.658 1.258.438 1.9l2.658 2.66c.645-.223 1.387-.078 1.9.435.721.72.721 1.884 0 2.604-.719.719-1.881.719-2.6 0-.539-.541-.674-1.337-.404-1.996L12.86 8.955v6.525c.176.086.342.203.488.348.713.721.713 1.883 0 2.6-.719.721-1.883.721-2.6 0-.719-.719-.719-1.883 0-2.6.177-.176.383-.309.602-.395V8.882c-.219-.086-.425-.218-.602-.395-.543-.543-.674-1.344-.4-2.005L7.636 3.7.45 10.881c-.6.605-.6 1.584 0 2.189l10.48 10.477c.604.604 1.582.604 2.186 0l10.43-10.43c.605-.603.605-1.582 0-2.187" />
+    </svg>
+  )
+}
+
+function NextjsIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path d="M18.665 21.978C16.758 23.255 14.465 24 12 24 5.377 24 0 18.623 0 12S5.377 0 12 0s12 5.377 12 12c0 3.583-1.574 6.801-4.067 9.001L9.219 7.2H7.2v9.596h1.615V9.251l9.85 12.727Zm-3.332-8.533 1.6 2.061V7.2h-1.6v6.245Z" />
+    </svg>
+  )
+}
+
 export const vendorIcons: Record<string, IconComponent> = {
   Anthropic: AnthropicIcon,
   OpenAI: OpenAIIcon,
@@ -125,6 +141,8 @@ export const vendorIcons: Record<string, IconComponent> = {
   Shopify: ShopifyIcon,
   HubSpot: HubSpotIcon,
   GitHub: GitHubIcon,
+  Git: GitIcon,
+  'Next.js': NextjsIcon,
   Mistral: MistralIcon,
   Ollama: OllamaIcon,
   'LM Studio': LMStudioIcon,

--- a/src/components/layout/animated-section.tsx
+++ b/src/components/layout/animated-section.tsx
@@ -19,6 +19,27 @@ const RevealContext = createContext<{ isVisible: boolean; reduced: boolean }>({
   reduced: false,
 })
 
+/**
+ * The hero plays a scripted intro on page load (see .hero-* in globals.css); its
+ * last element, the CTA, finishes at ~3.6s delay + 0.8s = 4.4s. A section that
+ * happens to be visible on load (tall screens) would otherwise reveal in the
+ * middle of that intro and beat it. This returns how long such a section should
+ * wait so it reveals only once the hero is done — anchored to first paint so a
+ * section scrolled to later isn't delayed. Returns 0 when there's no hero on the
+ * page, under reduced motion, or once the intro has already finished.
+ */
+const HERO_ENTRANCE_MS = 4500
+function heroGateRemainingMs(): number {
+  if (typeof window === 'undefined') return 0
+  if (!document.querySelector('[data-pts-hero]')) return 0
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return 0
+  const paint = performance
+    .getEntriesByType('paint')
+    .find(p => p.name === 'first-contentful-paint')
+  const start = paint?.startTime ?? 0
+  return Math.max(0, start + HERO_ENTRANCE_MS - performance.now())
+}
+
 export function AnimatedSection({
   className,
   children,
@@ -48,11 +69,19 @@ export function AnimatedSection({
       return
     }
 
+    let gateTimer: ReturnType<typeof setTimeout> | undefined
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          setIsVisible(true)
           observer.disconnect()
+          // If this section is visible while the hero intro is still playing,
+          // hold it until the intro finishes; otherwise reveal immediately.
+          const delay = heroGateRemainingMs()
+          if (delay > 0) {
+            gateTimer = setTimeout(() => setIsVisible(true), delay)
+          } else {
+            setIsVisible(true)
+          }
         }
       },
       // threshold 0 (fire as soon as any part enters) so tall sections still
@@ -62,7 +91,10 @@ export function AnimatedSection({
     )
 
     observer.observe(node)
-    return () => observer.disconnect()
+    return () => {
+      observer.disconnect()
+      if (gateTimer) clearTimeout(gateTimer)
+    }
   }, [])
 
   return (

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -38,7 +38,7 @@ export function HeroSection() {
             </h1>
           </div>
 
-          {/* Supporting subtext + audit CTA — stacked, subtext leads */}
+          {/* Supporting subtext + audit CTA */}
           <div className='flex flex-col gap-8'>
             <div className='hero-reveal flex self-start gap-4' style={{ animationDelay: '3.3s' }}>
               {/* Vertical leader line */}

--- a/src/components/sections/manifesto-section.tsx
+++ b/src/components/sections/manifesto-section.tsx
@@ -1,24 +1,28 @@
-import { Cog, DraftingCompass, MessageSquare } from 'lucide-react'
 import Link from 'next/link'
 import { AnimatedSection, Reveal } from '@/src/components/layout/animated-section'
 import { BlueprintCorners } from '@/src/components/layout/dot-grid-background'
+import {
+  DraftingGraphic,
+  AiNativeGraphic,
+  DirectAccessGraphic,
+} from '@/src/components/graphics/home-graphics'
 
 const facets = [
   {
     title: 'Senior Builders',
-    Icon: DraftingCompass,
+    Graphic: DraftingGraphic,
     description:
       'The engineer who architects your solution is the one who builds it. No account managers, no layers of delegation.',
   },
   {
     title: 'AI-Native',
-    Icon: Cog,
+    Graphic: AiNativeGraphic,
     description:
       'Fine-tuned AI systems let us design and ship exactly what you need, at 3-5x the speed of a traditional team.',
   },
   {
     title: 'Direct Access',
-    Icon: MessageSquare,
+    Graphic: DirectAccessGraphic,
     description:
       'You work with the builder directly. No middle management, no handoffs, no telephone game.',
   },
@@ -66,9 +70,7 @@ export function ManifestoSection() {
                   <h3 className='font-headline text-xl font-semibold tracking-tight text-text'>
                     {facet.title}
                   </h3>
-                  <span className='inline-flex h-9 w-9 shrink-0 items-center justify-center'>
-                    <facet.Icon className='h-4 w-4 text-accent' aria-hidden />
-                  </span>
+                  <facet.Graphic className='h-grid-2 w-grid-2 shrink-0' />
                 </div>
                 <p className='text-sm leading-relaxed text-text-muted'>
                   {facet.description}

--- a/src/components/sections/phases-section.tsx
+++ b/src/components/sections/phases-section.tsx
@@ -3,11 +3,17 @@ import { AnimatedSection, Reveal } from '@/src/components/layout/animated-sectio
 import { BlueprintCorners } from '@/src/components/layout/dot-grid-background'
 import { vendors } from '@/src/lib/vendors'
 import { vendorIcons } from '@/src/components/icons/vendor-icons'
+import {
+  PrototypeGraphic,
+  RefineGraphic,
+  ScaleGraphic,
+  RnDGraphic,
+} from '@/src/components/graphics/home-graphics'
 
 const phases = [
   {
-    number: '01',
     title: 'Prototype',
+    Graphic: PrototypeGraphic,
     points: [
       'Test new product ideas',
       'Prove product-market fit',
@@ -15,8 +21,8 @@ const phases = [
     ],
   },
   {
-    number: '02',
     title: 'Refine',
+    Graphic: RefineGraphic,
     points: [
       'Streamline existing systems',
       'Automate the manual work',
@@ -24,8 +30,8 @@ const phases = [
     ],
   },
   {
-    number: '03',
     title: 'Scale',
+    Graphic: ScaleGraphic,
     points: [
       'Re-architect your stack',
       'Rethink operations for demand',
@@ -33,8 +39,8 @@ const phases = [
     ],
   },
   {
-    number: '04',
     title: 'R&D',
+    Graphic: RnDGraphic,
     points: [
       'Analyze your data',
       'Unlock new revenue vectors',
@@ -42,6 +48,30 @@ const phases = [
     ],
   },
 ]
+
+/** One scrolling row of the trust banner. Vendors are duplicated so the loop is
+ *  seamless; `reverse` flips the scroll direction. */
+function TrustTrack({ reverse = false, className }: { reverse?: boolean; className?: string }) {
+  return (
+    <div className={`marquee ${className ?? ''}`}>
+      <div className={`marquee-track ${reverse ? 'marquee-track-rev' : ''}`}>
+        {[...vendors, ...vendors].map((vendor, i) => {
+          const Icon = vendorIcons[vendor.name]
+          return (
+            <div key={`${vendor.name}-${i}`} className='flex shrink-0 items-center gap-2.5 px-6'>
+              {Icon && (
+                <Icon className='h-7 w-7 shrink-0' style={{ color: vendor.color }} aria-hidden />
+              )}
+              <span className='whitespace-nowrap font-mono text-[10px] uppercase tracking-wider text-text-muted'>
+                {vendor.name}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
 
 export function PhasesSection({
   showHowWeWorkLink = true,
@@ -83,21 +113,23 @@ export function PhasesSection({
           )}
         </div>
 
-        {/* Phase grid — 4 cols, blueprint-style with corner marks */}
+        {/* Phase grid: 4 cols, blueprint-style with corner marks */}
         <Reveal index={2} className='relative'>
           <BlueprintCorners size={16} />
           <div className='grid gap-px border border-border bg-border md:grid-cols-4'>
-            {phases.map(phase => (
+            {phases.map(phase => {
+              const Graphic = phase.Graphic
+              return (
               <div
-                key={phase.number}
+                key={phase.title}
                 className='relative flex flex-col gap-4 bg-bg-card p-5 md:p-8'
               >
-                <div className='flex flex-col gap-1'>
-                  <span className='font-mono text-xs text-accent'>{phase.number}</span>
-                  <h3 className='font-headline text-xl font-semibold tracking-tight text-text'>
-                    {phase.title}
-                  </h3>
-                </div>
+                {Graphic && (
+                  <Graphic className='absolute right-4 top-4 h-grid-3 w-grid-3 md:right-6 md:top-6 md:h-grid-2 md:w-grid-2' />
+                )}
+                <h3 className='font-headline text-xl font-semibold tracking-tight text-text'>
+                  {phase.title}
+                </h3>
                 <ul className='flex flex-col gap-2 text-sm leading-relaxed text-text-muted'>
                   {phase.points.map(point => (
                     <li key={point} className='flex gap-2'>
@@ -107,7 +139,8 @@ export function PhasesSection({
                   ))}
                 </ul>
               </div>
-            ))}
+              )
+            })}
           </div>
         </Reveal>
 
@@ -125,25 +158,11 @@ export function PhasesSection({
                 and human-verified for production-grade quality.
               </p>
             </div>
-            <div className='relative grid grid-cols-2 gap-x-6 gap-y-5 p-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7'>
-                <BlueprintCorners size={16} />
-                {vendors.map(vendor => {
-                  const Icon = vendorIcons[vendor.name]
-                  return (
-                    <div key={vendor.name} className='flex items-center gap-2.5'>
-                      {Icon && (
-                        <Icon
-                          className='h-7 w-7 shrink-0'
-                          style={{ color: vendor.color }}
-                          aria-hidden
-                        />
-                      )}
-                      <span className='whitespace-nowrap font-mono text-[10px] uppercase tracking-wider text-text-muted'>
-                        {vendor.name}
-                      </span>
-                    </div>
-                  )
-                })}
+            {/* Auto-scrolling trust banner: one row on desktop, two rows scrolling
+                opposite directions on mobile. Full-bleed to the section edges. */}
+            <div className='-mx-6 flex flex-col gap-4 lg:-mx-12'>
+              <TrustTrack />
+              <TrustTrack reverse className='md:hidden' />
             </div>
           </Reveal>
         )}

--- a/src/components/sections/pillars-section.tsx
+++ b/src/components/sections/pillars-section.tsx
@@ -1,23 +1,27 @@
-import { Building2, Database, Filter } from 'lucide-react'
 import { AnimatedSection, Reveal } from '@/src/components/layout/animated-section'
 import { BlueprintCorners } from '@/src/components/layout/dot-grid-background'
+import {
+  SeatsGraphic,
+  CentralizedDataGraphic,
+  NoBloatGraphic,
+} from '@/src/components/graphics/home-graphics'
 
 const pillars = [
   {
     title: 'No Per-Seat Pricing',
-    Icon: Building2,
+    Graphic: SeatsGraphic,
     description:
       'You own the tech infrastructure. Add as many users as your business needs without watching the bill climb. No per-seat licensing, no penalty for growing your team.',
   },
   {
     title: 'Centralized Business Data',
-    Icon: Database,
+    Graphic: CentralizedDataGraphic,
     description:
       'All your business data lives in one place, structured and transparent. That single source of truth keeps the system modular, so you can extend it without rebuilding from scratch.',
   },
   {
     title: 'No SaaS Feature Bloat',
-    Icon: Filter,
+    Graphic: NoBloatGraphic,
     description:
       'You get exactly the features your business runs on, nothing more. No paying for bloated dashboards and modules you will never open.',
   },
@@ -50,10 +54,8 @@ export function PillarsSection() {
               className='relative flex flex-col gap-4 bg-bg-card p-5 md:p-8'
             >
               <BlueprintCorners size={16} />
-              <span className='absolute right-5 top-5 inline-flex h-9 w-9 items-center justify-center md:right-8 md:top-8'>
-                <pillar.Icon className='h-4 w-4 text-accent' aria-hidden />
-              </span>
-              <h3 className='font-headline text-xl font-semibold tracking-tight text-text'>
+              <pillar.Graphic className='absolute right-4 top-4 h-grid-2 w-grid-2 md:right-6 md:top-6' />
+              <h3 className='max-w-[calc(100%-3.5rem)] font-headline text-xl font-semibold tracking-tight text-text'>
                 {pillar.title}
               </h3>
               <p className='max-w-xl text-sm !leading-snug text-accent-secondary'>

--- a/src/components/sections/services-preview.tsx
+++ b/src/components/sections/services-preview.tsx
@@ -1,25 +1,23 @@
 'use client'
 
-import type { CSSProperties } from 'react'
 import { useId, useState } from 'react'
 import Link from 'next/link'
 import { ChevronDown } from 'lucide-react'
 import { AnimatedSection, Reveal } from '@/src/components/layout/animated-section'
 import { services, type Service } from '@/src/lib/services'
-import { serviceIcons } from '@/src/lib/service-icons'
+import { serviceGraphics } from '@/src/components/graphics/home-graphics'
 import { cn } from '@/src/lib/utils'
 
 type ServiceRowProps = {
   service: Service
-  index: number
   isOpen: boolean
   onToggle: () => void
 }
 
-function ServiceRow({ service, index, isOpen, onToggle }: ServiceRowProps) {
+function ServiceRow({ service, isOpen, onToggle }: ServiceRowProps) {
   const id = useId()
   const contentId = `${id}-content`
-  const Icon = serviceIcons[service.icon]
+  const Graphic = serviceGraphics[service.icon]
 
   return (
     <div className='border-b border-border bg-bg-card last:border-b-0'>
@@ -31,13 +29,7 @@ function ServiceRow({ service, index, isOpen, onToggle }: ServiceRowProps) {
         aria-controls={contentId}
         className='flex w-full items-start gap-4 p-5 text-left transition-colors hover:bg-bg-elevated focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent/30 md:px-6 md:py-6'
       >
-        {Icon && (
-          <Icon
-            className='service-icon mt-0.5 h-5 w-5 shrink-0 text-accent'
-            style={{ '--icon-delay': `${index * 0.9}s` } as CSSProperties}
-            aria-hidden
-          />
-        )}
+        {Graphic && <Graphic className='mt-0.5 h-grid-2 w-grid-2 shrink-0' />}
         <div className='flex flex-col gap-1'>
           <h3 className='font-headline text-lg font-semibold tracking-tight text-text'>
             {service.title}
@@ -63,7 +55,7 @@ function ServiceRow({ service, index, isOpen, onToggle }: ServiceRowProps) {
         )}
       >
         <div className='overflow-hidden'>
-          <div className='flex flex-col gap-4 px-5 pb-6 md:px-6 md:pl-[3.75rem]'>
+          <div className='flex flex-col gap-4 px-5 pb-6 md:px-6 md:pl-[5.5rem]'>
             <p className='text-sm leading-relaxed text-text-muted'>
               {service.description}
             </p>
@@ -122,7 +114,6 @@ export function ServicesPreview() {
             <ServiceRow
               key={service.slug}
               service={service}
-              index={i}
               isOpen={activeIndex === i}
               onToggle={() =>
                 setActiveIndex(prev => (prev === i ? null : i))

--- a/src/components/sections/who-we-work-with-section.tsx
+++ b/src/components/sections/who-we-work-with-section.tsx
@@ -1,23 +1,31 @@
 import Link from 'next/link'
 import { AnimatedSection } from '@/src/components/layout/animated-section'
 import { BlueprintCorners } from '@/src/components/layout/dot-grid-background'
+import {
+  LeanMarketGraphic,
+  FounderGraphic,
+  DesignLedGraphic,
+} from '@/src/components/graphics/home-graphics'
 
 const profiles = [
   {
     number: '01',
     title: 'The Lean Mid-Market',
+    Graphic: LeanMarketGraphic,
     description:
       "You're established with real processes in place, but not big enough to justify a full-time dev team. You need senior engineering to optimize and extend your systems without the cost of hiring one.",
   },
   {
     number: '02',
     title: 'The Technical Founder',
+    Graphic: FounderGraphic,
     description:
       "You're technical enough to prototype in AI tools and ship a scrappy v1. But you've hit the ceiling where vibe-coded solutions break, and you need real engineering to make it production-grade.",
   },
   {
     number: '03',
     title: 'The Design-Led Team',
+    Graphic: DesignLedGraphic,
     description:
       'You have the vision, the designers, maybe some technical staff, but no engineering team to execute. You know exactly what you want built. You just need the builders to make it real.',
   },
@@ -49,6 +57,7 @@ export function WhoWeWorkWithSection() {
               className='relative flex flex-col gap-4 border border-border bg-bg-card p-5 md:p-8'
             >
               <BlueprintCorners size={12} />
+              <profile.Graphic className='absolute right-4 top-4 h-grid-2 w-grid-2 md:right-6 md:top-6' />
               <span className='inline-flex h-6 w-6 items-center justify-center border border-accent/40 font-mono text-[10px] text-accent'>
                 {profile.number}
               </span>

--- a/src/lib/vendors.ts
+++ b/src/lib/vendors.ts
@@ -64,6 +64,20 @@ export const vendors: Vendor[] = [
     color: '#FFFFFF',
   },
   {
+    name: 'Git',
+    url: 'https://git-scm.com',
+    description: 'Distributed version control',
+    category: 'infra',
+    color: '#F05032',
+  },
+  {
+    name: 'Next.js',
+    url: 'https://nextjs.org',
+    description: 'React framework for the web',
+    category: 'infra',
+    color: '#FFFFFF',
+  },
+  {
     name: 'Anthropic',
     url: 'https://www.anthropic.com',
     description: 'AI reasoning & code generation',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,9 @@ const config: Config = {
           DEFAULT: '#2a2b30',
           light: '#3a3b40',
         },
+        // Mid-grey for schematic line-work — readable on card backgrounds,
+        // where border-light is too dark to see.
+        line: '#6e7078',
         // Keep old tokens as aliases for backward compatibility during migration
         ink: {
           DEFAULT: '#0e0f11',


### PR DESCRIPTION
## Summary

Adds animated blueprint-schematic graphics across the homepage and refines how sections animate in.

### Graphics
- New animated blueprint schematics for the homepage sections (pillars, manifesto, who-we-work-with, services), matching the thin, hollow, single-accent language of the how-we-work page.
- Graphics added to the "How We Work" phase cards; phase numbers removed, icons kept. Phase graphics render larger on mobile where there's vertical room.
- Card schematics brightened (new `line` token) so they read against the card backgrounds.
- The "Under the hood" vendor grid became an auto-scrolling trust banner — one row on desktop, two rows scrolling opposite directions on mobile (slower on mobile).

### Hero
- A "Built for everyone vs Built for you" comparison set piece was built for the hero (`hero-graphic.tsx`) in the site's blueprint style, but is **shelved** for now (not rendered) so the rest of the animations can ship. The hero is back to its single-column subtext/CTA layout.

### Section reveal timing
- `AnimatedSection` now holds any section that's visible on page load until the hero intro finishes (~4.4s), anchored to first paint so a section scrolled to later isn't delayed. No-ops when there's no hero on the page and under reduced motion.

## Notes
- All new motion respects `prefers-reduced-motion`.
- `npx tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)