### PR TITLE
Fix all ESLint errors: unescaped entities and setState-in-effect

### DIFF
--- a/src/components/floating-book-cta.tsx
+++ b/src/components/floating-book-cta.tsx
@@ -1,26 +1,27 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useSyncExternalStore } from 'react'
 import { usePathname } from 'next/navigation'
 import { BookCallLink } from '@/src/components/book-call-link'
 
+// sessionStorage never notifies same-document writes, but the flag is only set
+// on landing pages (where this CTA is hidden), so the re-render caused by the
+// pathname change on navigation is enough to pick up a fresh snapshot.
+const subscribe = () => () => {}
+const getSnapshot = () => !!sessionStorage.getItem('pts-landing-session')
+const getServerSnapshot = () => false
+
 export function FloatingBookCta() {
   const pathname = usePathname()
-  const [visible, setVisible] = useState(false)
+  const hasLandingSession = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot
+  )
 
   const isLandingPage = pathname.startsWith('/book-a-call/')
 
-  useEffect(() => {
-    if (isLandingPage) {
-      setVisible(false)
-      return
-    }
-
-    const hasLandingSession = sessionStorage.getItem('pts-landing-session')
-    setVisible(!!hasLandingSession)
-  }, [isLandingPage])
-
-  if (!visible) return null
+  if (isLandingPage || !hasLandingSession) return null
 
   return (
     <div className='fixed right-6 bottom-6 z-50 duration-500 animate-in fade-in slide-in-from-bottom-4'>

--- a/src/components/graphics/blueprint-graphic.tsx
+++ b/src/components/graphics/blueprint-graphic.tsx
@@ -4,11 +4,22 @@ import {
   useEffect,
   useRef,
   useState,
+  useSyncExternalStore,
   type CSSProperties,
   type ReactNode,
   type SVGProps,
 } from 'react'
 import { cn } from '@/src/lib/utils'
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
+
+const subscribeReducedMotion = (onChange: () => void) => {
+  const mql = window.matchMedia(REDUCED_MOTION_QUERY)
+  mql.addEventListener('change', onChange)
+  return () => mql.removeEventListener('change', onChange)
+}
+const getReducedMotion = () => window.matchMedia(REDUCED_MOTION_QUERY).matches
+const getServerReducedMotion = () => false
 
 /**
  * Fires once when the element first scrolls into view. Under prefers-reduced-motion
@@ -17,21 +28,21 @@ import { cn } from '@/src/lib/utils'
  */
 export function useInView<T extends Element = HTMLElement>() {
   const ref = useRef<T>(null)
-  const [inView, setInView] = useState(false)
+  const [intersected, setIntersected] = useState(false)
+  const reducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotion,
+    getServerReducedMotion
+  )
 
   useEffect(() => {
     const node = ref.current
-    if (!node) return
-
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      setInView(true)
-      return
-    }
+    if (!node || reducedMotion) return
 
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          setInView(true)
+          setIntersected(true)
           observer.disconnect()
         }
       },
@@ -40,9 +51,9 @@ export function useInView<T extends Element = HTMLElement>() {
 
     observer.observe(node)
     return () => observer.disconnect()
-  }, [])
+  }, [reducedMotion])
 
-  return { ref, inView }
+  return { ref, inView: reducedMotion || intersected }
 }
 
 interface BlueprintGraphicProps extends SVGProps<SVGSVGElement> {

--- a/src/components/sections/contact-section.tsx
+++ b/src/components/sections/contact-section.tsx
@@ -72,7 +72,7 @@ export function ContactSection() {
       <div className='flex flex-col items-center gap-4 text-center'>
         <span className='bp-label font-mono'>Contact</span>
         <h2 className='max-w-5xl font-headline text-3xl leading-[.9]! font-semibold text-balance text-text uppercase md:text-5xl'>
-          Let's talk
+          Let&apos;s talk
         </h2>
         <p className='max-w-xl text-lg leading-snug! text-balance text-text-muted'>
           Send a message and we&apos;ll get back to you within one business day.

--- a/src/components/sections/faq-section.tsx
+++ b/src/components/sections/faq-section.tsx
@@ -105,12 +105,12 @@ export function FaqSection() {
           FAQ
         </span>
         <h2 className='max-w-4xl font-headline text-3xl leading-[.9]! font-semibold text-balance text-text uppercase md:text-5xl'>
-          The answers you're looking for
+          The answers you&apos;re looking for
         </h2>
         <p className='max-w-2xl text-lg leading-snug! text-balance text-text-muted'>
           The essentials that most clients ask us before we kick off a new
-          engagement. Please reach out if you have other questions. We're happy
-          to answer them!
+          engagement. Please reach out if you have other questions. We&apos;re
+          happy to answer them!
         </p>
       </div>
       <FaqAccordion />

--- a/src/components/sections/use-cases-section.tsx
+++ b/src/components/sections/use-cases-section.tsx
@@ -58,7 +58,7 @@ export function UseCasesSection({
           Real products helping businesses
         </h2>
         <p className='max-w-xl text-base leading-snug! text-balance text-ink/80 md:text-lg'>
-          Custom solutions we've built for real-world business needs.
+          Custom solutions we&apos;ve built for real-world business needs.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- Escape apostrophes flagged by `react/no-unescaped-entities` in the contact, FAQ, and use-cases sections
- Fix both "calling setState synchronously within an effect" errors with the idiomatic `useSyncExternalStore` pattern:
  - `FloatingBookCta` now derives visibility from the `pts-landing-session` sessionStorage flag during render (no state, no effect)
  - `useInView` (blueprint graphics) reads `prefers-reduced-motion` via `useSyncExternalStore` with a live `change` subscription; the IntersectionObserver keeps its async state update

`npm run lint` now passes with 0 errors (one pre-existing `no-img-element` warning remains in the clients section).

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `tsc --noEmit` passes
- [x] Verified in the dev server: blueprint graphics still draw in on scroll (`data-visible` flips as each enters the viewport), all `AnimatedSection`s reveal, floating CTA hidden without the session flag, shown on non-landing pages with it, hidden on `/book-a-call/*`, and appears after client-side navigation off a landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)