### PR TITLE
Make the opportunity audit the primary CTA funnel

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -43,7 +43,7 @@ export default function ClientsPage() {
               <Reveal index={0} className='flex flex-col gap-3'>
                 <span className='bp-label font-mono'>Next Step</span>
                 <h2 className='font-headline text-3xl font-bold tracking-tight text-text md:text-4xl'>
-                  Ready to build?
+                  Find where to start.
                 </h2>
               </Reveal>
               <Reveal
@@ -51,8 +51,9 @@ export default function ClientsPage() {
                 className='max-w-md text-sm leading-relaxed text-text-muted'
               >
                 <p>
-                  Tell us what you are trying to build. We will scope the work,
-                  timeline, and cost, with no obligation.
+                  The free audit pinpoints the phase your business is in and
+                  where custom software pays off first. Two minutes, results on
+                  screen, no obligation.
                 </p>
               </Reveal>
             </div>
@@ -61,8 +62,8 @@ export default function ClientsPage() {
               className='flex w-full shrink-0 flex-col gap-4 sm:w-auto'
             >
               <Button asChild size='lg' className='w-full'>
-                <TrackedLink href='/contact' location='clients-cta-block'>
-                  Start a Project
+                <TrackedLink href='/audit' location='clients-cta-block'>
+                  Start the free audit
                 </TrackedLink>
               </Button>
               <div className='flex flex-col gap-2'>
@@ -72,13 +73,13 @@ export default function ClientsPage() {
                   variant='outline'
                   className='w-full border-2'
                 >
-                  <TrackedLink href='/audit' location='clients-cta-block'>
-                    Opportunity Audit
+                  <TrackedLink href='/contact' location='clients-cta-block'>
+                    Contact Us
                   </TrackedLink>
                 </Button>
                 <p className='max-w-xs text-xs leading-relaxed text-text-muted'>
-                  Not sure where to start? This two-minute audit pinpoints where
-                  custom software pays off first.
+                  Already know what you want built, or want a bespoke mapping of
+                  your systems? Talk to us directly.
                 </p>
               </div>
             </Reveal>

--- a/app/how-we-work/page.tsx
+++ b/app/how-we-work/page.tsx
@@ -138,28 +138,29 @@ export default function HowWeWorkPage() {
             <div className='flex flex-col gap-3'>
               <span className='bp-label font-mono'>Next Step</span>
               <h2 className='font-headline text-3xl font-bold tracking-tight text-text md:text-4xl'>
-                Ready to build?
+                Find your phase.
               </h2>
               <p className='max-w-md text-sm leading-relaxed text-text-muted'>
-                Tell us what you are trying to build. We will scope the work,
-                timeline, and cost, with no obligation.
+                The free audit pinpoints the phase your business is in and where
+                custom software pays off first. Two minutes, results on screen,
+                no obligation.
               </p>
             </div>
             <div className='flex w-full shrink-0 flex-col gap-4 sm:w-auto'>
               <Button asChild size='lg' className='w-full'>
-                <TrackedLink href='/contact' location='how-we-work-cta-block'>
-                  Start a Project
+                <TrackedLink href='/audit' location='how-we-work-cta-block'>
+                  Start the free audit
                 </TrackedLink>
               </Button>
               <div className='flex flex-col gap-2'>
                 <Button asChild size='lg' variant='outline' className='w-full border-2'>
-                  <TrackedLink href='/audit' location='how-we-work-cta-block'>
-                    Opportunity Audit
+                  <TrackedLink href='/contact' location='how-we-work-cta-block'>
+                    Contact Us
                   </TrackedLink>
                 </Button>
                 <p className='max-w-xs text-xs leading-relaxed text-text-muted'>
-                  Not sure where to start? This two-minute audit pinpoints
-                  where custom software pays off first.
+                  Already know what you want built, or want a bespoke mapping of
+                  your systems? Talk to us directly.
                 </p>
               </div>
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ export default function HomePage() {
       <HeroSection />
       <ClientLogosSection />
       <WhoWeWorkWithSection />
-      <PhasesSection showPoweredBy />
+      <PhasesSection showPoweredBy showAuditLink />
       <ServicesPreview />
       <ManifestoSection />
       <PillarsSection />
@@ -36,7 +36,7 @@ export default function HomePage() {
               <Reveal index={0} className='flex flex-col gap-3'>
                 <span className='bp-label font-mono'>Next Step</span>
                 <h2 className='font-headline text-3xl font-bold tracking-tight text-text md:text-4xl'>
-                  Ready to build?
+                  Find where to start.
                 </h2>
               </Reveal>
               <Reveal
@@ -44,8 +44,9 @@ export default function HomePage() {
                 className='max-w-md text-sm leading-relaxed text-text-muted'
               >
                 <p>
-                  Tell us what you are trying to build. We will scope the work,
-                  timeline, and cost, with no obligation.
+                  The free audit pinpoints the phase your business is in and
+                  where custom software pays off first. Two minutes, results on
+                  screen, no obligation.
                 </p>
               </Reveal>
             </div>
@@ -54,8 +55,8 @@ export default function HomePage() {
               className='flex w-full shrink-0 flex-col gap-4 sm:w-auto'
             >
               <Button asChild size='lg' className='w-full'>
-                <TrackedLink href='/contact' location='home-cta-block'>
-                  Start a Project
+                <TrackedLink href='/audit' location='home-cta-block'>
+                  Start the free audit
                 </TrackedLink>
               </Button>
               <div className='flex flex-col gap-2'>
@@ -65,13 +66,13 @@ export default function HomePage() {
                   variant='outline'
                   className='w-full border-2'
                 >
-                  <TrackedLink href='/audit' location='home-cta-block'>
-                    Opportunity Audit
+                  <TrackedLink href='/contact' location='home-cta-block'>
+                    Contact Us
                   </TrackedLink>
                 </Button>
                 <p className='max-w-xs text-xs leading-relaxed text-text-muted'>
-                  Not sure where to start? This two-minute audit pinpoints where
-                  custom software pays off first.
+                  Already know what you want built, or want a bespoke mapping of
+                  your systems? Talk to us directly.
                 </p>
               </div>
             </Reveal>

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -74,17 +74,18 @@ export default function ServicesPage() {
             <div className='flex flex-col gap-3'>
               <span className='bp-label font-mono'>Next Step</span>
               <h2 className='font-headline text-3xl font-bold tracking-tight text-text md:text-4xl'>
-                Ready to build?
+                Not sure which you need?
               </h2>
               <p className='max-w-md text-sm leading-relaxed text-text-muted'>
-                Tell us what you are trying to build. We will scope the work,
-                timeline, and cost, with no obligation.
+                The free audit pinpoints the phase your business is in and picks
+                the services that pay off first. Two minutes, results on screen,
+                no obligation.
               </p>
             </div>
             <div className='flex w-full shrink-0 flex-col gap-4 sm:w-auto'>
               <Button asChild size='lg' className='w-full'>
-                <TrackedLink href='/contact' location='services-cta-block'>
-                  Start a Project
+                <TrackedLink href='/audit' location='services-cta-block'>
+                  Start the free audit
                 </TrackedLink>
               </Button>
               <div className='flex flex-col gap-2'>
@@ -94,13 +95,13 @@ export default function ServicesPage() {
                   variant='outline'
                   className='w-full border-2'
                 >
-                  <TrackedLink href='/audit' location='services-cta-block'>
-                    Opportunity Audit
+                  <TrackedLink href='/contact' location='services-cta-block'>
+                    Contact Us
                   </TrackedLink>
                 </Button>
                 <p className='max-w-xs text-xs leading-relaxed text-text-muted'>
-                  Not sure where to start? This two-minute audit pinpoints where
-                  custom software pays off first.
+                  Already know what you want built, or want a bespoke mapping of
+                  your systems? Talk to us directly.
                 </p>
               </div>
             </div>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -66,8 +66,8 @@ export function Header() {
         <div className='flex items-center gap-4'>
           <div className='hidden md:inline-flex'>
             <Button asChild size='sm'>
-              <TrackedLink href='/contact' location='header'>
-                Start a Project
+              <TrackedLink href='/audit' location='header'>
+                Free Audit
               </TrackedLink>
             </Button>
           </div>
@@ -136,11 +136,11 @@ export function Header() {
             <div className='mt-3 px-4'>
               <Button asChild size='sm' className='w-full'>
                 <TrackedLink
-                  href='/contact'
+                  href='/audit'
                   location='header-mobile'
                   onClick={() => setMobileOpen(false)}
                 >
-                  Start a Project
+                  Free Audit
                 </TrackedLink>
               </Button>
             </div>

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -56,10 +56,11 @@ export function HeroSection() {
                     No more juggling a stack of bloated SaaS dashboards.
                   </p>
                   <p className='text-base leading-relaxed text-text-muted md:text-lg'>
-                    Not sure where to start? Take our free{' '}
+                    Take the{' '}
                     <strong className='font-semibold text-accent/70'>
-                      opportunity audit.
-                    </strong>
+                      free audit
+                    </strong>{' '}
+                    to see where custom software fits for your business.
                   </p>
                 </div>
               </div>
@@ -69,9 +70,12 @@ export function HeroSection() {
               >
                 <Button asChild size='lg' variant='primaryInvert'>
                   <TrackedLink href='/audit' location='hero' data-pts-hero-cta>
-                    Find your opportunities
+                    Start the free audit
                   </TrackedLink>
                 </Button>
+                <p className='font-mono text-[11px] tracking-[0.08em] text-text-muted'>
+                  2 minutes, free results, no email required.
+                </p>
               </div>
             </div>
 

--- a/src/components/sections/phases-section.tsx
+++ b/src/components/sections/phases-section.tsx
@@ -175,16 +175,22 @@ export function PhasesSection({
 
         {showAuditLink && (
           <Reveal index={3}>
-            <p className='text-base leading-relaxed text-text-muted'>
-              Not sure which phase you are in?{' '}
-              <TrackedLink
-                href='/audit'
-                location='home-phases'
-                className='font-semibold text-accent underline decoration-accent/40 underline-offset-4 transition-colors hover:text-accent/80'
-              >
-                Find out in 2 minutes
-              </TrackedLink>
-              , free.
+            {/* Each clause is an inline-block so a narrow viewport breaks the
+                line between them instead of orphaning a word or two. */}
+            <p className='text-base leading-relaxed text-balance text-text-muted'>
+              <span className='inline-block'>
+                Not sure which phase you are in?
+              </span>{' '}
+              <span className='inline-block'>
+                <TrackedLink
+                  href='/audit'
+                  location='home-phases'
+                  className='font-semibold text-accent underline decoration-accent/40 underline-offset-4 transition-colors hover:text-accent/80'
+                >
+                  Find out in 2 minutes
+                </TrackedLink>
+                , free.
+              </span>
             </p>
           </Reveal>
         )}

--- a/src/components/sections/phases-section.tsx
+++ b/src/components/sections/phases-section.tsx
@@ -4,6 +4,7 @@ import {
   Reveal,
 } from '@/src/components/layout/animated-section'
 import { BlueprintCorners } from '@/src/components/layout/dot-grid-background'
+import { TrackedLink } from '@/src/components/tracked-link'
 import { vendors } from '@/src/lib/vendors'
 import { vendorIcons } from '@/src/components/icons/vendor-icons'
 import {
@@ -93,10 +94,14 @@ export function PhasesSection({
   showHowWeWorkLink = true,
   showPoweredBy = false,
   showLabel = true,
+  showAuditLink = false,
 }: {
   showHowWeWorkLink?: boolean
   showPoweredBy?: boolean
   showLabel?: boolean
+  /** Prompts the reader into the audit right under the phase cards. The audit's
+   *  first output is the phase you are in, so this is where that question lands. */
+  showAuditLink?: boolean
 }) {
   return (
     <AnimatedSection className='py-20'>
@@ -167,6 +172,22 @@ export function PhasesSection({
             })}
           </div>
         </Reveal>
+
+        {showAuditLink && (
+          <Reveal index={3}>
+            <p className='text-base leading-relaxed text-text-muted'>
+              Not sure which phase you are in?{' '}
+              <TrackedLink
+                href='/audit'
+                location='home-phases'
+                className='font-semibold text-accent underline decoration-accent/40 underline-offset-4 transition-colors hover:text-accent/80'
+              >
+                Find out in 2 minutes
+              </TrackedLink>
+              , free.
+            </p>
+          </Reveal>
+        )}
 
         {/* Under The Hood — the method behind every stage plus the tools that power
             it. Folds the how-we-work process into the intro, then the vendor logos. */}

--- a/src/components/sections/services-preview.tsx
+++ b/src/components/sections/services-preview.tsx
@@ -89,6 +89,34 @@ function ServiceRow({ service, isOpen, onToggle }: ServiceRowProps) {
   )
 }
 
+/** Audit prompt that closes out the service list. Rendered in two places so it
+ *  can sit in the sticky left column on desktop but fall below the cards on
+ *  mobile, matching where the other homepage sections put their audit CTA.
+ *  Each clause is an inline-block so the line breaks between them rather than
+ *  orphaning a word or two onto the second line. */
+function AuditPrompt({ className }: { className?: string }) {
+  return (
+    <p
+      className={cn(
+        'text-base leading-relaxed text-balance text-text-muted',
+        className
+      )}
+    >
+      <span className='inline-block'>Not sure which of these you need?</span>{' '}
+      <span className='inline-block'>
+        <TrackedLink
+          href='/audit'
+          location='home-services-preview'
+          className='font-semibold text-accent underline decoration-accent/40 underline-offset-4 transition-colors hover:text-accent/80'
+        >
+          This free audit picks for you
+        </TrackedLink>
+        .
+      </span>
+    </p>
+  )
+}
+
 export function ServicesPreview() {
   const [activeIndex, setActiveIndex] = useState<number | null>(null)
 
@@ -115,18 +143,9 @@ export function ServicesPreview() {
               <span aria-hidden>&rarr;</span>
             </Link>
           </Reveal>
-          <Reveal index={3}>
-            <p className='border-t border-border pt-4 text-base leading-relaxed text-text-muted'>
-              Not sure which of these you need?{' '}
-              <TrackedLink
-                href='/audit'
-                location='home-services-preview'
-                className='font-semibold text-accent underline decoration-accent/40 underline-offset-4 transition-colors hover:text-accent/80'
-              >
-                The free audit picks them for you
-              </TrackedLink>
-              .
-            </p>
+          {/* Desktop: rides along in the sticky column */}
+          <Reveal index={3} className='hidden md:block'>
+            <AuditPrompt className='border-t border-border pt-4' />
           </Reveal>
         </div>
 
@@ -140,6 +159,12 @@ export function ServicesPreview() {
               onToggle={() => setActiveIndex(prev => (prev === i ? null : i))}
             />
           ))}
+        </Reveal>
+
+        {/* Mobile: falls below the cards. `md:hidden` keeps it out of the grid
+            entirely on desktop, so the two-column layout is unaffected. */}
+        <Reveal index={3} className='md:hidden'>
+          <AuditPrompt />
         </Reveal>
       </div>
     </AnimatedSection>

--- a/src/components/sections/services-preview.tsx
+++ b/src/components/sections/services-preview.tsx
@@ -7,6 +7,7 @@ import {
   AnimatedSection,
   Reveal,
 } from '@/src/components/layout/animated-section'
+import { TrackedLink } from '@/src/components/tracked-link'
 import { services, type Service } from '@/src/lib/services'
 import { serviceGraphics } from '@/src/components/graphics/home-graphics'
 import { cn } from '@/src/lib/utils'
@@ -113,6 +114,19 @@ export function ServicesPreview() {
               View all services
               <span aria-hidden>&rarr;</span>
             </Link>
+          </Reveal>
+          <Reveal index={3}>
+            <p className='border-t border-border pt-4 text-base leading-relaxed text-text-muted'>
+              Not sure which of these you need?{' '}
+              <TrackedLink
+                href='/audit'
+                location='home-services-preview'
+                className='font-semibold text-accent underline decoration-accent/40 underline-offset-4 transition-colors hover:text-accent/80'
+              >
+                The free audit picks them for you
+              </TrackedLink>
+              .
+            </p>
           </Reveal>
         </div>
 

--- a/src/components/sections/who-we-work-with-section.tsx
+++ b/src/components/sections/who-we-work-with-section.tsx
@@ -72,16 +72,22 @@ export function WhoWeWorkWithSection() {
           ))}
         </div>
 
-        <p className='text-base leading-relaxed text-text-muted'>
-          Recognize yourself in one of these?{' '}
-          <TrackedLink
-            href='/audit'
-            location='home-who-we-work-with'
-            className='font-semibold text-accent underline decoration-accent/40 underline-offset-4 transition-colors hover:text-accent/80'
-          >
-            The free audit shows where to start
-          </TrackedLink>
-          .
+        {/* Each clause is an inline-block so a narrow viewport breaks the line
+            between them instead of orphaning a word or two. */}
+        <p className='text-base leading-relaxed text-balance text-text-muted'>
+          <span className='inline-block'>
+            Recognize yourself in one of these?
+          </span>{' '}
+          <span className='inline-block'>
+            <TrackedLink
+              href='/audit'
+              location='home-who-we-work-with'
+              className='font-semibold text-accent underline decoration-accent/40 underline-offset-4 transition-colors hover:text-accent/80'
+            >
+              The free audit shows where to start
+            </TrackedLink>
+            .
+          </span>
         </p>
       </div>
     </AnimatedSection>

--- a/src/components/sections/who-we-work-with-section.tsx
+++ b/src/components/sections/who-we-work-with-section.tsx
@@ -1,5 +1,6 @@
 import { AnimatedSection } from '@/src/components/layout/animated-section'
 import { BlueprintCorners } from '@/src/components/layout/dot-grid-background'
+import { TrackedLink } from '@/src/components/tracked-link'
 import {
   LeanMarketGraphic,
   FounderGraphic,
@@ -70,6 +71,18 @@ export function WhoWeWorkWithSection() {
             </div>
           ))}
         </div>
+
+        <p className='text-base leading-relaxed text-text-muted'>
+          Recognize yourself in one of these?{' '}
+          <TrackedLink
+            href='/audit'
+            location='home-who-we-work-with'
+            className='font-semibold text-accent underline decoration-accent/40 underline-offset-4 transition-colors hover:text-accent/80'
+          >
+            The free audit shows where to start
+          </TrackedLink>
+          .
+        </p>
       </div>
     </AnimatedSection>
   )


### PR DESCRIPTION
Reverses the CTA priority across the site so the opportunity audit is the main funnel and `/contact` becomes the secondary path for people who already know what they want built.

## Why

The audit was the secondary CTA everywhere: an outline button sitting behind "Start a Project", captioned "Not sure where to start?". That framing positioned it as a fallback for confused visitors, so anyone feeling confident skipped it. The homepage also ran six consecutive sections between the hero and the footer CTA with no conversion path at all.

## Changes

**Header** (desktop + mobile) — "Start a Project" becomes "Free Audit", pointing at `/audit`. Contact remains in the nav, so high-intent visitors keep a direct route.

**Hero** — button reads "Start the free audit". The supporting sentence drops the fallback framing, and a micro-line underneath reads "2 minutes, free results, no email required." That claim is accurate: `results-view.tsx` renders the phase timeline and service recommendations on screen immediately, and the capture form below them only exists to email a copy.

**Three new mid-page CTAs on the homepage**, written as inline sentences rather than buttons so they read as helpful rather than salesy:

| Section | Copy |
|---|---|
| Phases, under the four cards | "Not sure which phase you are in? *Find out in 2 minutes*, free." |
| Who We Work With, after the profiles | "Recognize yourself in one of these? *The free audit shows where to start*." |
| Services preview, sticky left column | "Not sure which of these you need? *The free audit picks them for you*." |

The phases placement is the strongest fit, since the audit's first output is literally the phase you are in.

**CTA blocks flipped** on `/`, `/services`, `/clients` and `/how-we-work`: the audit is now the filled primary, contact drops to the outline secondary with the caption "Already know what you want built, or want a bespoke mapping of your systems? Talk to us directly." Headings are varied per page rather than repeating one line four times.

## Notes

- `PhasesSection` gains a `showAuditLink` prop defaulting to `false`, so the `/how-we-work` rendering of that section is untouched.
- **Analytics:** the `cta_click` `location` values are all unchanged, so existing funnels keep working. But `destination` flips from `/contact` to `/audit` on the four CTA blocks, so any saved chart filtering on destination will show a discontinuity at this deploy.
- `how-we-work-section.tsx` still has a `/contact` button, but that component is not imported anywhere and is dead code. Left alone.
- `results-view.tsx` still points at `/contact` after the audit completes. That direction is correct: the audit funnels *into* contact.

`npm run build` and `tsc --noEmit` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)