### PR TITLE
Real legal page copy, plus explicit mailing-list opt-in

### DIFF
--- a/app/actions/send-audit.ts
+++ b/app/actions/send-audit.ts
@@ -94,7 +94,7 @@ export async function sendAudit(
     } as const
   }
 
-  const { name, email, company } = parsed.data
+  const { name, email, company, marketingConsent } = parsed.data
 
   const resend = new Resend(apiKey)
 
@@ -173,7 +173,9 @@ export async function sendAudit(
   }
 
   // Best-effort: add contact to Resend audience. Never blocks success.
-  if (audienceId) {
+  // Requires explicit opt-in — asking for audit results is not consent to
+  // marketing, so an unticked box means we skip the audience entirely.
+  if (audienceId && marketingConsent) {
     const contactPayload: {
       email: string
       audienceId: string
@@ -213,7 +215,7 @@ export async function sendAudit(
     } catch (error) {
       console.error('Resend contact creation failed', error)
     }
-  } else {
+  } else if (!audienceId) {
     console.warn('RESEND_AUDIENCE_ID not set; skipping audience add')
   }
 

--- a/app/actions/send-contact.ts
+++ b/app/actions/send-contact.ts
@@ -84,7 +84,8 @@ export async function sendContact(
     } as const
   }
 
-  const { name, email, message, company, website } = parsed.data
+  const { name, email, message, company, website, marketingConsent } =
+    parsed.data
 
   const resend = new Resend(apiKey)
 
@@ -178,7 +179,9 @@ export async function sendContact(
   }
 
   // Best-effort: add contact to Resend audience. Never blocks success.
-  if (audienceId) {
+  // Requires explicit opt-in — replying to an enquiry is not consent to
+  // marketing, so an unticked box means we skip the audience entirely.
+  if (audienceId && marketingConsent) {
     const contactPayload: {
       email: string
       audienceId: string
@@ -218,7 +221,7 @@ export async function sendContact(
     } catch (error) {
       console.error('Resend contact creation failed', error)
     }
-  } else {
+  } else if (!audienceId) {
     console.warn('RESEND_AUDIENCE_ID not set; skipping audience add')
   }
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,40 +1,288 @@
-export const metadata = {
-  title: 'Privacy Policy | Place To Stand',
+import type { Metadata } from 'next'
+import { AnimatedSection } from '@/src/components/layout/animated-section'
+import {
+  LegalHeader,
+  LegalList,
+  LegalSection,
+} from '@/src/components/legal/legal-prose'
+
+const UPDATED = 'July 29, 2026'
+const CONTACT_EMAIL = 'hello@placetostandagency.com'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
   description:
-    'Learn how Place To Stand collects, uses, and protects your personal information when you engage with our services.',
+    'How Place To Stand collects, uses, shares, and protects personal information submitted through our website, contact form, and opportunity audit.',
 }
 
 export default function PrivacyPage() {
   return (
-    <main className='mx-auto mt-28 flex min-h-screen w-full max-w-4xl flex-col gap-8 px-6 py-24'>
-      <section className='space-y-4'>
-        <h1 className='font-headline text-5xl tracking-[0.1em] text-text uppercase'>
-          Privacy Policy
-        </h1>
-        <p className='text-base text-text-muted'>
-          We respect your privacy and are committed to safeguarding your data.
-          This placeholder page summarises how we collect, use, and protect
-          information submitted through our contact form and other interactions
-          with Place To Stand. A fully detailed policy will be published prior
-          to launch.
-        </p>
-      </section>
-      <section className='space-y-3 text-sm text-text-muted'>
-        <h2 className='font-headline text-2xl tracking-[0.2em] text-text uppercase'>
-          Key Principles
-        </h2>
-        <ul className='space-y-2'>
-          <li>
-            • We only collect information necessary to respond to your
-            enquiries.
-          </li>
-          <li>• We never sell your personal data to third parties.</li>
-          <li>
-            • You may request data removal or updates at any time by contacting
-            hello@placetostandagency.com.
-          </li>
-        </ul>
-      </section>
+    <main className='flex-1 pb-grid-4'>
+      <AnimatedSection priority>
+        <div className='flex flex-col gap-grid-2'>
+          <LegalHeader
+            title='Privacy Policy'
+            updated={UPDATED}
+            summary='This policy explains what we collect when you use placetostandagency.com, why we collect it, who we share it with, and the choices you have.'
+          />
+
+          <div className='flex flex-col gap-grid-2'>
+            <LegalSection index={1} title='Who this policy covers'>
+              <p>
+                Place To Stand is a software studio operating from Austin, Texas
+                and Brooklyn, New York. This policy applies to
+                placetostandagency.com and to the forms and tools hosted on it,
+                including our contact form and the Opportunity Audit.
+              </p>
+              <p>
+                It does not cover work we perform under a signed client
+                agreement. Data we process on a client&apos;s behalf during an
+                engagement is governed by that agreement, not by this policy.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={2} title='Information you give us'>
+              <p>We collect information only when you choose to send it.</p>
+              <LegalList
+                items={[
+                  <>
+                    <strong className='text-text'>Contact form:</strong> your
+                    name, email address, and message, plus your company name and
+                    website if you provide them.
+                  </>,
+                  <>
+                    <strong className='text-text'>Opportunity Audit:</strong>{' '}
+                    your name, email address, optional company name, the answers
+                    you select during the audit, and the recommendations we
+                    generate from them.
+                  </>,
+                  <>
+                    <strong className='text-text'>
+                      Direct correspondence:
+                    </strong>{' '}
+                    anything you send us by email.
+                  </>,
+                ]}
+              />
+              <p>
+                We do not ask for payment card details, government identifiers,
+                or any special category data through this website. Please do not
+                send sensitive personal information through our forms.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={3} title='Information collected automatically'>
+              <p>
+                When you browse the site we collect usage data through analytics
+                tools. This includes pages viewed, referring pages, approximate
+                location derived from IP address, device and browser type, and
+                interactions such as clicks and scroll depth.
+              </p>
+              <p>
+                Our product analytics run through a first-party subdomain
+                (t.placetostandagency.com). We create a persistent analytics
+                profile only for visitors who identify themselves by submitting
+                a form. Everyone else is measured anonymously.
+              </p>
+              <p>
+                We also run automated bot detection on form submissions to block
+                spam, and our hosting provider keeps standard server logs
+                including IP addresses.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={4} title='Cookies and similar technologies'>
+              <p>
+                We use cookies and browser storage for three purposes: to make
+                the site work, to measure how it is used, and to measure the
+                performance of our advertising.
+              </p>
+              <LegalList
+                items={[
+                  <>
+                    <strong className='text-text'>Analytics:</strong> PostHog
+                    and Vercel Analytics, used to understand which pages and
+                    features people actually use.
+                  </>,
+                  <>
+                    <strong className='text-text'>Advertising:</strong> a Google
+                    Ads conversion tag, used to attribute enquiries to the ads
+                    that produced them.
+                  </>,
+                ]}
+              />
+              <p>
+                You can block or delete cookies through your browser settings.
+                Doing so will not prevent you from using the site. We honour
+                Global Privacy Control signals where your browser sends them.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={5} title='How we use your information'>
+              <LegalList
+                items={[
+                  'To reply to your enquiry and send you a copy of what you submitted.',
+                  'To generate and deliver your Opportunity Audit results.',
+                  'To evaluate whether we are a good fit for your project and to prepare a proposal.',
+                  'To send occasional updates about our work, if you have opted in.',
+                  'To understand how the site is used and improve it.',
+                  'To detect and block spam and abuse.',
+                  'To meet our legal and accounting obligations.',
+                ]}
+              />
+              <p>
+                We do not sell your personal information, and we do not share it
+                with third parties for their own marketing.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={6} title='Who we share it with'>
+              <p>
+                We share personal information with a small number of service
+                providers who process it on our instructions:
+              </p>
+              <LegalList
+                items={[
+                  <>
+                    <strong className='text-text'>Vercel:</strong> website
+                    hosting, traffic analytics, and bot detection.
+                  </>,
+                  <>
+                    <strong className='text-text'>Resend:</strong> delivery of
+                    transactional and marketing email, and storage of our
+                    mailing list.
+                  </>,
+                  <>
+                    <strong className='text-text'>PostHog:</strong> product
+                    analytics.
+                  </>,
+                  <>
+                    <strong className='text-text'>Google:</strong> advertising
+                    conversion measurement.
+                  </>,
+                  <>
+                    <strong className='text-text'>
+                      Our own client portal:
+                    </strong>{' '}
+                    infrastructure we operate to track enquiries through to
+                    proposal.
+                  </>,
+                ]}
+              />
+              <p>
+                We may also disclose information where required by law, or in
+                connection with a merger or sale of the business. In that case
+                we will tell you before your information becomes subject to a
+                different policy.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={7} title='Email and marketing'>
+              <p>
+                When you submit the contact form or complete the audit, we add
+                your name and email address to our mailing list so we can follow
+                up and share occasional updates. Every marketing email includes
+                an unsubscribe link, and unsubscribing takes effect immediately.
+              </p>
+              <p>
+                Unsubscribing does not stop transactional messages such as
+                replies to your enquiry or your audit results. You can ask us to
+                remove you entirely by emailing {CONTACT_EMAIL}.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={8} title='How long we keep it'>
+              <p>
+                Enquiry and audit records are kept for three years from your
+                last contact with us, so we have context if you return. Mailing
+                list entries are kept until you unsubscribe. Analytics data is
+                kept according to our providers&apos; standard retention
+                periods. Records we need for tax and accounting are kept as long
+                as the law requires.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={9} title='Your rights'>
+              <p>
+                Wherever you live, you can ask us to give you a copy of the
+                personal information we hold about you, correct it, or delete
+                it. Email {CONTACT_EMAIL} and we will respond within 30 days.
+              </p>
+              <p>
+                If you are in the European Economic Area or the United Kingdom,
+                you also have the right to object to or restrict processing, to
+                data portability, and to lodge a complaint with your data
+                protection authority. We process your information on the basis
+                of your consent (for marketing and non-essential cookies), our
+                legitimate interest in operating and improving our business (for
+                analytics and responding to enquiries), and our legal
+                obligations.
+              </p>
+              <p>
+                If you are a California resident, you have the right to know
+                what we collect, to request deletion or correction, and to opt
+                out of sale or sharing. We do not sell or share personal
+                information as those terms are defined under California law. We
+                will not discriminate against you for exercising any of these
+                rights.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={10} title='International transfers'>
+              <p>
+                We are based in the United States and our service providers
+                process data in the United States. If you contact us from
+                outside the US, your information will be transferred there. We
+                rely on standard contractual clauses with our providers where
+                those transfers involve personal data protected under European
+                or UK law.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={11} title='Security'>
+              <p>
+                Data is transmitted over encrypted connections and held with
+                established providers that maintain their own security
+                programmes. Access within our team is limited to the people who
+                need it. No system is perfectly secure, and we cannot guarantee
+                absolute security, but we will notify affected people and
+                regulators as required if a breach occurs.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={12} title="Children's privacy">
+              <p>
+                This site is intended for businesses and is not directed at
+                anyone under 16. We do not knowingly collect information from
+                children. If you believe a child has sent us personal
+                information, contact us and we will delete it.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={13} title='Changes to this policy'>
+              <p>
+                We will update this page when our practices change and revise
+                the date at the top. If a change materially affects how we use
+                information you already gave us, we will contact you directly.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={14} title='Contact us'>
+              <p>
+                Questions about this policy or a request about your data can go
+                to{' '}
+                <a
+                  href={`mailto:${CONTACT_EMAIL}`}
+                  className='text-accent underline-offset-4 hover:underline'
+                >
+                  {CONTACT_EMAIL}
+                </a>
+                .
+              </p>
+            </LegalSection>
+          </div>
+        </div>
+      </AnimatedSection>
     </main>
   )
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -179,15 +179,17 @@ export default function PrivacyPage() {
 
             <LegalSection index={7} title='Email and marketing'>
               <p>
-                When you submit the contact form or complete the audit, we add
-                your name and email address to our mailing list so we can follow
-                up and share occasional updates. Every marketing email includes
-                an unsubscribe link, and unsubscribing takes effect immediately.
+                We add your name and email address to our mailing list only if
+                you tick the opt-in box on the contact form or the audit. The
+                box is unticked by default, and leaving it that way has no
+                effect on your enquiry or your audit results.
               </p>
               <p>
-                Unsubscribing does not stop transactional messages such as
-                replies to your enquiry or your audit results. You can ask us to
-                remove you entirely by emailing {CONTACT_EMAIL}.
+                Every marketing email includes an unsubscribe link, and
+                unsubscribing takes effect immediately. Unsubscribing does not
+                stop transactional messages such as replies to your enquiry or
+                your audit results. You can ask us to remove you entirely by
+                emailing {CONTACT_EMAIL}.
               </p>
             </LegalSection>
 

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,41 +1,241 @@
-export const metadata = {
-  title: 'Terms of Service | Place To Stand',
+import type { Metadata } from 'next'
+import { AnimatedSection } from '@/src/components/layout/animated-section'
+import {
+  LegalHeader,
+  LegalList,
+  LegalSection,
+} from '@/src/components/legal/legal-prose'
+
+const UPDATED = 'July 29, 2026'
+const CONTACT_EMAIL = 'hello@placetostandagency.com'
+// Texas, confirmed by the business. Place To Stand also operates out of
+// Brooklyn, NY, so this is a deliberate choice rather than an inferred default.
+const GOVERNING_LAW = 'the State of Texas'
+
+export const metadata: Metadata = {
+  title: 'Terms of Service',
   description:
-    'Understand the engagement terms, responsibilities, and usage guidelines when partnering with Place To Stand.',
+    'The terms that govern use of the Place To Stand website and the Opportunity Audit, and the general conditions under which we deliver client work.',
 }
 
 export default function TermsPage() {
   return (
-    <main className='mx-auto mt-28 flex min-h-screen w-full max-w-4xl flex-col gap-8 px-6 py-24'>
-      <section className='space-y-4'>
-        <h1 className='font-headline text-5xl tracking-[0.1em] text-text uppercase'>
-          Terms of Service
-        </h1>
-        <p className='text-base text-text-muted'>
-          These terms outline the general conditions under which Place To Stand
-          delivers strategy, design, and development services. The content below
-          acts as a placeholder until the full legal agreement is finalised.
-        </p>
-      </section>
-      <section className='space-y-3 text-sm text-text-muted'>
-        <h2 className='font-headline text-2xl tracking-[0.2em] text-text uppercase'>
-          Highlights
-        </h2>
-        <ul className='space-y-2'>
-          <li>
-            • Engagements begin with a mutual statement of work defining scope,
-            deliverables, and timeline.
-          </li>
-          <li>
-            • Intellectual property is transferred to the client upon receipt of
-            final payment, unless otherwise agreed.
-          </li>
-          <li>
-            • Clients agree to provide timely feedback and access to the
-            resources required to complete the project.
-          </li>
-        </ul>
-      </section>
+    <main className='flex-1 pb-grid-4'>
+      <AnimatedSection priority>
+        <div className='flex flex-col gap-grid-2'>
+          <LegalHeader
+            title='Terms of Service'
+            updated={UPDATED}
+            summary='These terms govern your use of placetostandagency.com and the tools on it. Client engagements are governed by a separate signed agreement, which takes precedence over anything here.'
+          />
+
+          <div className='flex flex-col gap-grid-2'>
+            <LegalSection index={1} title='Agreement to these terms'>
+              <p>
+                By using this website you agree to these terms. If you do not
+                agree, please do not use the site. We may update these terms
+                from time to time, and the date at the top reflects the current
+                version. Continuing to use the site after a change means you
+                accept the revised terms.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={2} title='What we do'>
+              <p>
+                Place To Stand is a software studio. We provide strategy,
+                design, and software development services to businesses. This
+                website describes those services and lets you get in touch or
+                request an Opportunity Audit. Nothing on this site is an offer
+                to enter into a contract, and no engagement begins until both
+                parties sign a written agreement.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={3} title='The Opportunity Audit'>
+              <p>
+                The Opportunity Audit is a free informational tool. It scores
+                the answers you provide and suggests categories of work that may
+                be relevant to your situation.
+              </p>
+              <p>
+                It is not professional, legal, financial, or technical advice,
+                and it is not a substitute for a proper discovery process. The
+                recommendations are generated from a short questionnaire and
+                reflect only what you told us. We make no guarantee that acting
+                on them will produce any particular outcome, and you are
+                responsible for any decision you make on the basis of your
+                results.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={4} title='Engagements and statements of work'>
+              <p>
+                Client work begins with a mutual statement of work that defines
+                scope, deliverables, timeline, and price. Where a statement of
+                work or master services agreement conflicts with these terms,
+                that document controls.
+              </p>
+              <p>
+                Changes to an agreed scope are handled by written change order.
+                We will tell you the cost and schedule impact before proceeding.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={5} title='Fees and payment'>
+              <p>
+                Fees, payment schedule, and invoicing terms are set in each
+                statement of work. Unless stated otherwise, invoices are due
+                within 15 days of receipt. We may pause work on overdue accounts
+                after giving written notice. Fees are exclusive of taxes and of
+                third-party costs such as hosting and software licences, which
+                are your responsibility unless we agree otherwise in writing.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={6} title='Your responsibilities'>
+              <p>Delivery depends on your participation. You agree to:</p>
+              <LegalList
+                items={[
+                  'Provide timely feedback, decisions, and approvals.',
+                  'Give us the access, accounts, credentials, and information we need to do the work.',
+                  'Ensure you have the rights to any content, data, or materials you give us.',
+                  'Designate someone with authority to make decisions on your behalf.',
+                ]}
+              />
+              <p>
+                Delays caused by outstanding feedback or access may shift the
+                schedule and, where they cause us to hold capacity, may affect
+                cost.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={7} title='Intellectual property'>
+              <p>
+                Ownership of the deliverables we create specifically for you
+                transfers to you once we have received payment in full, unless
+                your agreement says otherwise.
+              </p>
+              <p>
+                We retain ownership of anything we bring to the project that
+                predates it or that we develop for general use, including our
+                internal tools, libraries, frameworks, and know-how. Where those
+                components are embedded in your deliverables, we grant you a
+                perpetual, worldwide, non-exclusive licence to use them as part
+                of those deliverables.
+              </p>
+              <p>
+                Third-party and open-source components remain subject to their
+                own licences. We may describe the work publicly and include it
+                in our portfolio unless you ask us in writing not to.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={8} title='Confidentiality'>
+              <p>
+                Each party will protect the other&apos;s confidential
+                information, use it only for the purpose of the engagement, and
+                not disclose it to anyone who does not need it. This does not
+                apply to information that is public, already known, or
+                independently developed, or where disclosure is required by law.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={9} title='Acceptable use of this site'>
+              <p>
+                Do not use this site to break the law, interfere with its
+                operation, attempt to gain unauthorised access, scrape it at a
+                volume that degrades service, or submit false information
+                through our forms. We may block access for any of these reasons.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={10} title='Third-party services'>
+              <p>
+                This site and our work rely on third-party providers such as
+                hosting platforms, email services, and analytics tools. We are
+                not responsible for their availability, performance, or acts,
+                and links to third-party sites are provided for convenience
+                without endorsement.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={11} title='Disclaimers'>
+              <p>
+                This website and the Opportunity Audit are provided &quot;as
+                is&quot; and &quot;as available&quot;, without warranties of any
+                kind, whether express or implied, including implied warranties
+                of merchantability, fitness for a particular purpose, and
+                non-infringement. We do not warrant that the site will be
+                uninterrupted or error free.
+              </p>
+              <p>
+                Warranties covering client deliverables, if any, are set out in
+                the applicable statement of work.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={12} title='Limitation of liability'>
+              <p>
+                To the fullest extent permitted by law, Place To Stand will not
+                be liable for indirect, incidental, special, consequential, or
+                punitive damages, or for lost profits, revenue, data, or
+                business opportunity, arising out of your use of this site or
+                the Opportunity Audit.
+              </p>
+              <p>
+                Our total liability arising out of your use of this site is
+                limited to one hundred US dollars. Liability arising out of a
+                client engagement is limited as set out in the applicable
+                agreement. Nothing here limits liability that cannot be limited
+                by law.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={13} title='Indemnification'>
+              <p>
+                You agree to indemnify Place To Stand against claims, losses,
+                and reasonable costs arising from your misuse of this site, your
+                breach of these terms, or your infringement of a third
+                party&apos;s rights through material you provide to us.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={14} title='Termination'>
+              <p>
+                You may stop using this site at any time, and we may suspend or
+                end access to it at our discretion. Termination of a client
+                engagement is governed by the applicable agreement. Provisions
+                that by their nature should survive termination, including
+                intellectual property, confidentiality, disclaimers, and
+                limitation of liability, will do so.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={15} title='Governing law'>
+              <p>
+                These terms are governed by the laws of {GOVERNING_LAW}, without
+                regard to its conflict of law rules. The parties agree to the
+                exclusive jurisdiction of the state and federal courts located
+                there. Before filing a claim, please contact us so we can try to
+                resolve the matter directly.
+              </p>
+            </LegalSection>
+
+            <LegalSection index={16} title='Contact us'>
+              <p>
+                Questions about these terms can go to{' '}
+                <a
+                  href={`mailto:${CONTACT_EMAIL}`}
+                  className='text-accent underline-offset-4 hover:underline'
+                >
+                  {CONTACT_EMAIL}
+                </a>
+                .
+              </p>
+            </LegalSection>
+          </div>
+        </div>
+      </AnimatedSection>
     </main>
   )
 }

--- a/src/components/audit/results-view.tsx
+++ b/src/components/audit/results-view.tsx
@@ -23,6 +23,7 @@ import {
 import { BlueprintCorners } from '@/src/components/layout/dot-grid-background'
 import { TrackedLink } from '@/src/components/tracked-link'
 import { Button } from '@/src/components/ui/button'
+import { Checkbox } from '@/src/components/ui/checkbox'
 import { Input } from '@/src/components/ui/input'
 import { Label } from '@/src/components/ui/label'
 import { toast } from '@/src/components/ui/use-toast'
@@ -295,7 +296,12 @@ function CaptureForm({ result, answers }: CaptureFormProps) {
   const [isSuccess, setIsSuccess] = useState(false)
   const form = useForm<AuditLeadValues>({
     resolver: zodResolver(auditLeadSchema),
-    defaultValues: { name: '', email: '', company: '' },
+    defaultValues: {
+      name: '',
+      email: '',
+      company: '',
+      marketingConsent: false,
+    },
   })
 
   const onSubmit = form.handleSubmit(values => {
@@ -404,6 +410,20 @@ function CaptureForm({ result, answers }: CaptureFormProps) {
                   {form.formState.errors.company.message}
                 </p>
               ) : null}
+            </div>
+            <div className='flex items-start gap-3 pt-1'>
+              <Checkbox
+                id='audit-marketing-consent'
+                {...form.register('marketingConsent')}
+              />
+              <Label
+                htmlFor='audit-marketing-consent'
+                className='text-sm leading-snug font-normal text-text-muted'
+              >
+                Send me occasional updates about Place To Stand&apos;s work. You
+                will get your result either way, and you can unsubscribe at any
+                time.
+              </Label>
             </div>
             <Button
               type='submit'

--- a/src/components/legal/legal-prose.tsx
+++ b/src/components/legal/legal-prose.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react'
+
+type LegalHeaderProps = {
+  title: string
+  updated: string
+  summary: string
+}
+
+/** Title block shared by the privacy and terms pages. */
+export function LegalHeader({ title, updated, summary }: LegalHeaderProps) {
+  return (
+    <header className='flex flex-col gap-grid-1'>
+      <span className='bp-label font-mono'>Legal</span>
+      <h1 className='font-headline text-4xl leading-[0.95] font-bold tracking-tight text-text uppercase md:text-5xl'>
+        {title}
+      </h1>
+      <p className='max-w-2xl text-base text-text-muted'>{summary}</p>
+      <p className='font-mono text-xs text-text-muted'>
+        Last updated: {updated}
+      </p>
+    </header>
+  )
+}
+
+type LegalSectionProps = {
+  index: number
+  title: string
+  children: ReactNode
+}
+
+/** One numbered clause, using the same row-number gutter as the audit list. */
+export function LegalSection({ index, title, children }: LegalSectionProps) {
+  return (
+    <section className='grid gap-grid-half border-t border-border pt-grid-1 md:grid-cols-[3rem_1fr] md:gap-0'>
+      <span className='font-mono text-xs text-text-muted tabular-nums'>
+        {String(index).padStart(2, '0')}
+      </span>
+      <div className='flex flex-col gap-3'>
+        <h2 className='font-headline text-xl font-semibold tracking-tight text-text'>
+          {title}
+        </h2>
+        <div className='flex flex-col gap-3 text-sm leading-relaxed text-text-muted'>
+          {children}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/** Bulleted list styled with the accent tick used elsewhere on the site. */
+export function LegalList({ items }: { items: ReactNode[] }) {
+  return (
+    <ul className='flex flex-col gap-2'>
+      {items.map((item, index) => (
+        <li key={index} className='flex items-start gap-2'>
+          <span aria-hidden className='mt-2 h-px w-3 shrink-0 bg-accent' />
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/sections/contact-section.tsx
+++ b/src/components/sections/contact-section.tsx
@@ -8,6 +8,7 @@ import { usePostHog } from 'posthog-js/react'
 import { AnimatedSection } from '@/src/components/layout/animated-section'
 import { BlueprintCorners } from '@/src/components/layout/dot-grid-background'
 import { Button } from '@/src/components/ui/button'
+import { Checkbox } from '@/src/components/ui/checkbox'
 import { Input } from '@/src/components/ui/input'
 import { Label } from '@/src/components/ui/label'
 import { Textarea } from '@/src/components/ui/textarea'
@@ -33,6 +34,7 @@ export function ContactSection() {
       company: '',
       website: '',
       message: '',
+      marketingConsent: false,
     },
   })
 
@@ -159,6 +161,20 @@ export function ContactSection() {
                 {form.formState.errors.message.message}
               </p>
             ) : null}
+          </div>
+          <div className='flex items-start gap-3 pt-1'>
+            <Checkbox
+              id='marketingConsent'
+              {...form.register('marketingConsent')}
+            />
+            <Label
+              htmlFor='marketingConsent'
+              className='text-sm leading-snug font-normal text-text-muted'
+            >
+              Send me occasional updates about Place To Stand&apos;s work. We
+              will reply to your message either way, and you can unsubscribe at
+              any time.
+            </Label>
           </div>
           <div className='mt-auto pt-3'>
             <Button

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import type { InputHTMLAttributes } from 'react'
+import { cn } from '@/src/lib/utils'
+
+type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
+
+/**
+ * Native checkbox styled as a blueprint tick box. Uses `appearance-none` plus
+ * a CSS-drawn check so it inherits the site's border and accent tokens rather
+ * than the platform default, while staying a real input for forms and a11y.
+ */
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <input
+        type='checkbox'
+        ref={ref}
+        className={cn(
+          'relative mt-0.5 h-5 w-5 shrink-0 appearance-none border border-border bg-bg-card transition-colors',
+          'checked:border-accent checked:bg-accent',
+          'focus-visible:ring-1 focus-visible:ring-accent/40 focus-visible:outline-hidden',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          // Check mark: a rotated L drawn with borders, shown only when checked.
+          "after:absolute after:top-[2px] after:left-[6px] after:hidden after:h-[10px] after:w-[5px] after:rotate-45 after:border-r-2 after:border-b-2 after:border-ink after:content-['']",
+          'checked:after:block',
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Checkbox.displayName = 'Checkbox'
+
+export { Checkbox }

--- a/src/lib/validations/audit.ts
+++ b/src/lib/validations/audit.ts
@@ -11,6 +11,9 @@ export const auditLeadSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters.'),
   email: z.string().email('Please enter a valid email address.'),
   company: optionalString,
+  // Opt-in only. Absent or false means we still send the audit result, but the
+  // person is never added to the marketing audience.
+  marketingConsent: z.boolean().optional(),
 })
 
 export type AuditLeadValues = z.infer<typeof auditLeadSchema>

--- a/src/lib/validations/contact.ts
+++ b/src/lib/validations/contact.ts
@@ -21,6 +21,9 @@ export const contactSchema = z.object({
   company: optionalString,
   website: optionalUrl,
   message: z.string().min(10, 'Message must be at least 10 characters.'),
+  // Opt-in only. Absent or false means we reply to the enquiry but never add
+  // the person to the marketing audience.
+  marketingConsent: z.boolean().optional(),
 })
 
 export type ContactFormValues = z.infer<typeof contactSchema>


### PR DESCRIPTION
## What this does

Replaces the placeholder privacy and terms pages with real policy copy.

Both pages previously said so in their own body text. Privacy: *"This placeholder page summarises... A fully detailed policy will be published prior to launch."* Terms: *"acts as a placeholder until the full legal agreement is finalised."* On a live site collecting personal data through two forms, that is both a weak trust signal and an accuracy problem.

## The copy is written against the actual stack

Rather than dropping in a template, the disclosures were derived from what the code really does:

| Source | What it does |
| --- | --- |
| `app/actions/send-contact.ts` | name, email, company, website, message via Resend; also POSTs a lead to the portal endpoint |
| `app/actions/send-audit.ts` | name, email, company, plus audit answers and generated recommendations |
| `src/components/posthog-provider.tsx` | autocapture, pageleave, dead clicks, through the `t.placetostandagency.com` first-party proxy, `person_profiles: 'identified_only'` |
| `app/layout.tsx` | Vercel Analytics and the Google Ads conversion tag (`AW-18356348929`) |
| `botid/server` | bot detection on both form submissions |

Privacy is 14 clauses covering collection, automatic data, cookies, use, processors, marketing, retention, GDPR/UK and CCPA rights, transfers, security, children, changes, and contact. Terms is 16 clauses covering the site and the Opportunity Audit, deferring to the signed statement of work for anything engagement-specific. Governing law is Texas, confirmed by the business.

## Also in this PR

- New `src/components/legal/legal-prose.tsx` exporting `LegalHeader`, `LegalSection`, and `LegalList`, so both pages share one presentation layer. Clause numbering reuses the mono row-number gutter from the audit capabilities list.
- Layout moved onto `AnimatedSection` and the grid spacing tokens. The old `max-w-4xl` and `mt-28` values predated the container and 24px grid rules in `CLAUDE.md`.
- Both pages were already in `app/sitemap.ts` at priority `0.3` / `yearly` and linked from the footer. No routing or sitemap changes needed.

## Also in this PR: explicit mailing-list opt-in

Pending decision 1 from the original description is now resolved in code.

Both server actions previously called `resend.contacts.create` with `unsubscribed: false` on *every* submission, so sending an enquiry or requesting audit results silently enrolled the person in marketing, with no consent step and no record of consent.

- `marketingConsent` added as an optional boolean on both schemas.
- The audience call is gated on it in `send-contact.ts:184` and `send-audit.ts:178`. Absent or false means the reply and the audit result still send, but the audience is skipped entirely.
- Unticked checkbox added to the contact form and the audit capture form.
- New `src/components/ui/checkbox.tsx` primitive: native input with `appearance-none` and a CSS-drawn check, matching `Input`'s token usage without adding another Radix dependency.
- Privacy clause 7 rewritten to describe opt-in rather than automatic enrollment, so the policy and the code now agree.
- The `RESEND_AUDIENCE_ID not set` warning now fires only when that is actually the cause, instead of on every declined opt-in.

## Still pending: cookie consent banner

Deferred by request, tracked for a follow-up.

No consent component exists anywhere in `src` or `app`. The Google Ads tag and PostHog autocapture both fire on first paint for every visitor, including EU and UK ones.

The policy states that Global Privacy Control signals are honoured, which PostHog supports, but GPC is not a substitute for prior consent.

**Suggested fix:** a consent gate that defers the Google Ads tag and PostHog init until a choice is made, for EU/UK traffic at minimum.

## Review notes

- `tsc --noEmit`, `eslint`, and `prettier --check` all pass on every touched file. Five unrelated files fail `prettier --check` on `main` already and were left alone.
- `/privacy` and `/terms` verified rendering locally, all 30 clause headings present. `/contact` verified rendering the consent checkbox unticked, and the generated CSS confirmed to include the `checked:` and `after:` rules the custom checkbox depends on.
- **This is not legal advice.** The drafts are accurate and specific to this system, which beats boilerplate as a starting point, but counsel should review before publishing. Terms clauses 12 (limitation of liability) and 15 (governing law) especially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
