### PR TITLE
Capture audit and contact submissions in the portal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,15 @@
+##############
+#   RESEND   #
+##############
+
 RESEND_API_KEY=
 RESEND_AUDIENCE_ID=
 
-PORTAL_LEADS_TOKEN=
-PORTAL_LEADS_ENDPOINT=
+##############
+#   PORTAL   #
+##############
+
+AUDIT_INTAKE_TOKEN=
+CONTACT_INTAKE_TOKEN=
+
+PORTAL_API_BASE_URL=

--- a/README.md
+++ b/README.md
@@ -78,16 +78,32 @@ Environment variables:
 
 - `RESEND_API_KEY` — required for contact form submission
 - `RESEND_AUDIENCE_ID` — required; Resend audience that stores new leads
-- `PORTAL_LEADS_ENDPOINT` — required; `https://portal.<domain>/api/integrations/leads-intake`
-- `PORTAL_LEADS_TOKEN` — required; bearer token shared with the portal’s `LEADS_INTAKE_TOKEN`
+- `PORTAL_API_BASE_URL` — required; portal host, e.g. `https://portal.placetostandagency.com`
+- `AUDIT_INTAKE_TOKEN` — required; bearer token for the portal’s audit-responses endpoint
+- `CONTACT_INTAKE_TOKEN` — required; bearer token for the portal’s contact-submissions endpoint
 - `NEXT_PUBLIC_VERCEL_ANALYTICS_ID` — optional if using Vercel Analytics locally
 
-### Lead intake configuration
+### Form submission intake
 
-1. Generate a shared secret with `openssl rand -hex 32` (or another secure random string generator).
-2. Set the generated value as `LEADS_INTAKE_TOKEN` in the portal environment and `PORTAL_LEADS_TOKEN` in this marketing site.
-3. Point `PORTAL_LEADS_ENDPOINT` to the portal instance (e.g. `https://portal.placetostandagency.com/api/integrations/leads-intake`).
-4. Deploy both apps so the marketing site can post newly submitted leads directly into the portal board.
+Both marketing forms land in the portal’s `form_submissions` table, surfaced at **Sales → Submissions**.
+Leads are promoted from there by hand; the marketing site no longer creates portal leads directly.
+
+Every Opportunity Audit attempt is pushed, whether or not the visitor ever hands over an email. Progress
+is sent at each section boundary, again when results are scored, again on lead capture, and via
+`navigator.sendBeacon` when the tab closes mid-wizard. The portal upserts on the audit’s `sessionId`, so
+an attempt occupies one row no matter how many times it is pushed.
+
+1. Set `PORTAL_API_BASE_URL` to the portal instance. The integration paths are appended automatically.
+2. Obtain the two intake tokens out of band and set them as `AUDIT_INTAKE_TOKEN` and
+   `CONTACT_INTAKE_TOKEN`. They are separate so either can be rotated independently. Never commit them.
+
+Leave all three unset in local development. The audit route and the contact action then log each payload
+to the server console instead of forwarding it, so the whole flow is verifiable with no portal running.
+The payload contract lives in `docs/prds/005-form-submissions/README.md`.
+
+The audit beacons through the same-origin `app/api/audit-progress/route.ts` rather than posting to the
+portal from the browser: `navigator.sendBeacon` cannot set an `Authorization` header, and putting an
+intake token in the client bundle would publish a portal secret.
 
 ## Development Workflow
 

--- a/app/actions/send-audit.ts
+++ b/app/actions/send-audit.ts
@@ -13,8 +13,6 @@ import {
   renderAuditTeamEmail,
 } from '@/src/lib/emails/audit-emails'
 
-const WEBSITE_SOURCE_DETAIL = 'https://placetostandagency.com/audit'
-
 export type AuditActionResult =
   | { success: true }
   | {
@@ -46,7 +44,9 @@ function summarizeResult(result: AuditResult): string[] {
 export async function sendAudit(
   values: AuditLeadValues,
   result: AuditResult,
-  answers: AuditAnswers
+  answers: AuditAnswers,
+  /** Links this lead to its stored audit response row in the portal. */
+  auditSessionId?: string | null
 ): Promise<AuditActionResult> {
   const parsed = auditLeadSchema.safeParse(values)
   if (!parsed.success) {
@@ -84,8 +84,6 @@ export async function sendAudit(
 
   const apiKey = process.env.RESEND_API_KEY
   const audienceId = process.env.RESEND_AUDIENCE_ID
-  const portalLeadsEndpoint = process.env.PORTAL_LEADS_ENDPOINT
-  const portalLeadsToken = process.env.PORTAL_LEADS_TOKEN
 
   if (!apiKey) {
     return {
@@ -113,6 +111,10 @@ export async function sendAudit(
   }
 
   detailLines.push('', 'Opportunity Audit result:', ...resultLines)
+
+  if (auditSessionId) {
+    detailLines.push('', `Audit session: ${auditSessionId}`)
+  }
 
   const answerGroups = summarizeAnswers(answers)
   if (answerGroups.length > 0) {
@@ -219,42 +221,10 @@ export async function sendAudit(
     console.warn('RESEND_AUDIENCE_ID not set; skipping audience add')
   }
 
-  // Best-effort: create lead in portal. Never blocks success.
-  if (portalLeadsEndpoint && portalLeadsToken) {
-    const portalPayload = {
-      name: trimmedName || name,
-      email,
-      company: trimmedCompany,
-      website: null,
-      message: ['Opportunity Audit result:', ...resultLines].join('\n'),
-      sourceDetail: WEBSITE_SOURCE_DETAIL,
-    }
-
-    try {
-      const portalResponse = await fetch(portalLeadsEndpoint, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${portalLeadsToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(portalPayload),
-      })
-
-      if (!portalResponse.ok) {
-        const errorText = await portalResponse.text()
-        console.error('Failed to create portal lead', {
-          status: portalResponse.status,
-          statusText: portalResponse.statusText,
-          body: errorText,
-          payload: portalPayload,
-        })
-      }
-    } catch (error) {
-      console.error('Portal lead creation failed', error)
-    }
-  } else {
-    console.warn('Portal lead endpoint/token not set; skipping portal lead')
-  }
+  // The portal record for this audit is created by the progress pushes in
+  // `useAudit`, not here. A successful capture fires a `captured` push carrying
+  // the lead details, which upserts onto the same `sessionId` row. Nothing in
+  // this action talks to the portal.
 
   return {
     success: true,

--- a/app/actions/send-contact.ts
+++ b/app/actions/send-contact.ts
@@ -1,13 +1,21 @@
 'use server'
 
+import { headers } from 'next/headers'
 import { Resend } from 'resend'
 import { checkBotId } from 'botid/server'
 import {
   contactSchema,
   type ContactFormValues,
 } from '@/src/lib/validations/contact'
-
-const WEBSITE_SOURCE_DETAIL = 'https://placetostandagency.com/'
+import {
+  buildContactSubmissionPayload,
+  type ContactSubmissionContext,
+} from '@/src/lib/forms/contact-payload'
+import {
+  PORTAL_PATHS,
+  postToPortal,
+  resolvePortalTarget,
+} from '@/src/lib/forms/portal'
 
 export type ContactActionResult =
   | { success: true }
@@ -36,7 +44,12 @@ function isValidUrl(value: string): boolean {
 }
 
 export async function sendContact(
-  values: ContactFormValues
+  values: ContactFormValues,
+  /**
+   * Analytics, campaign, and device context gathered in the browser. Absent when
+   * the client could not collect it; the submission still goes to the portal.
+   */
+  submissionContext?: ContactSubmissionContext
 ): Promise<ContactActionResult> {
   const parsed = contactSchema.safeParse(values)
   if (!parsed.success) {
@@ -74,8 +87,6 @@ export async function sendContact(
 
   const apiKey = process.env.RESEND_API_KEY
   const audienceId = process.env.RESEND_AUDIENCE_ID
-  const portalLeadsEndpoint = process.env.PORTAL_LEADS_ENDPOINT
-  const portalLeadsToken = process.env.PORTAL_LEADS_TOKEN
 
   if (!apiKey) {
     return {
@@ -225,41 +236,43 @@ export async function sendContact(
     console.warn('RESEND_AUDIENCE_ID not set; skipping audience add')
   }
 
-  // Best-effort: create lead in portal. Never blocks success.
-  if (portalLeadsEndpoint && portalLeadsToken) {
-    const portalPayload = {
-      name: trimmedName || name,
-      email,
-      company: trimmedCompany,
-      website: validatedWebsite,
-      message: trimmedMessage || null,
-      sourceDetail: WEBSITE_SOURCE_DETAIL,
-    }
+  // Best-effort: record the submission in the portal. Never blocks success.
+  // Leads are promoted from Submissions by hand, so nothing is created directly.
+  if (submissionContext) {
+    const userAgent = (await headers()).get('user-agent')?.slice(0, 1024) ?? null
 
-    try {
-      const portalResponse = await fetch(portalLeadsEndpoint, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${portalLeadsToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(portalPayload),
+    const payload = buildContactSubmissionPayload({
+      context: submissionContext,
+      contact: {
+        name: trimmedName || name,
+        email,
+        company: trimmedCompany,
+        website: validatedWebsite,
+        message: trimmedMessage,
+        marketingConsent: marketingConsent ?? false,
+      },
+      userAgent,
+    })
+
+    const target = resolvePortalTarget(
+      PORTAL_PATHS.contactSubmissions,
+      process.env.CONTACT_INTAKE_TOKEN
+    )
+
+    if (target) {
+      await postToPortal(target, payload, {
+        submissionId: payload.submissionId,
       })
-
-      if (!portalResponse.ok) {
-        const errorText = await portalResponse.text()
-        console.error('Failed to create portal lead', {
-          status: portalResponse.status,
-          statusText: portalResponse.statusText,
-          body: errorText,
-          payload: portalPayload,
-        })
-      }
-    } catch (error) {
-      console.error('Portal lead creation failed', error)
+    } else {
+      // Dev affordance: log rather than silently drop, so the flow is
+      // verifiable locally with no portal running.
+      console.info(
+        'PORTAL_API_BASE_URL/CONTACT_INTAKE_TOKEN not set; contact submission not forwarded',
+        JSON.stringify(payload, null, 2)
+      )
     }
   } else {
-    console.warn('Portal lead endpoint/token not set; skipping portal lead')
+    console.warn('No submission context supplied; skipping portal submission')
   }
 
   return {

--- a/app/api/audit-progress/route.ts
+++ b/app/api/audit-progress/route.ts
@@ -1,0 +1,173 @@
+/**
+ * Receives audit progress from the browser and forwards it to the portal.
+ *
+ * A route rather than a server action for two reasons: `navigator.sendBeacon`
+ * can only target a URL, and the portal token has to stay server-side.
+ *
+ * Deliberately no `checkBotId` here. Beacon requests carry no BotID challenge
+ * token and would fail the check, and the worst an abusive caller achieves is a
+ * junk anonymous row: no email is sent, no PII is required, and the portal
+ * upserts on `sessionId` so repeats collapse into one record.
+ */
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import {
+  PORTAL_PATHS,
+  postToPortal,
+  resolvePortalTarget,
+} from '@/src/lib/forms/portal'
+
+/** Generous next to a real payload (~4KB), tight enough to stop abuse. */
+const MAX_BODY_BYTES = 32 * 1024
+
+const isoDate = z.string().datetime()
+
+const responseItemSchema = z.object({
+  questionId: z.string().max(128),
+  sectionId: z.string().max(128),
+  prompt: z.string().max(1024),
+  type: z.enum(['single', 'multi', 'text']),
+  value: z
+    .union([z.string().max(5000), z.array(z.string().max(256)).max(64)])
+    .nullable(),
+  labels: z.array(z.string().max(5000)).max(64),
+})
+
+const payloadSchema = z.object({
+  sessionId: z.string().uuid(),
+  status: z.enum(['in_progress', 'completed', 'captured', 'abandoned']),
+  trigger: z.enum([
+    'started',
+    'step_completed',
+    'scored',
+    'captured',
+    'abandoned',
+    'pagehide',
+  ]),
+  sourceDetail: z.string().max(255),
+  startedAt: isoDate,
+  updatedAt: isoDate,
+  completedAt: isoDate.nullable(),
+  progress: z.object({
+    furthestStepIndex: z.number().int().min(0).max(64),
+    stepsTotal: z.number().int().min(0).max(64),
+    answeredCount: z.number().int().min(0).max(512),
+    questionsTotal: z.number().int().min(0).max(512),
+    percentComplete: z.number().int().min(0).max(100),
+    durationMs: z.number().int().min(0),
+  }),
+  responses: z.array(responseItemSchema).max(128),
+  result: z
+    .object({
+      phaseId: z.string().max(64),
+      phaseName: z.string().max(128),
+      summary: z.string().max(5000),
+      generatedBy: z.enum(['rules', 'ai']),
+      phaseScores: z.record(z.string(), z.number()),
+      recommendations: z
+        .array(
+          z.object({
+            serviceId: z.string().max(64),
+            serviceName: z.string().max(128),
+            score: z.number(),
+            reasons: z.array(z.string().max(512)).max(16),
+          })
+        )
+        .max(16),
+    })
+    .nullable(),
+  lead: z
+    .object({
+      name: z.string().max(160),
+      email: z.string().email().max(320),
+      company: z.string().max(160).nullable(),
+      marketingConsent: z.boolean(),
+    })
+    .nullable(),
+  analytics: z.object({
+    posthogDistinctId: z.string().max(256).nullable(),
+    posthogSessionId: z.string().max(256).nullable(),
+    posthogReplayUrl: z.string().max(2048).nullable(),
+  }),
+  attribution: z.object({
+    utmSource: z.string().max(256).nullable(),
+    utmMedium: z.string().max(256).nullable(),
+    utmCampaign: z.string().max(256).nullable(),
+    utmTerm: z.string().max(256).nullable(),
+    utmContent: z.string().max(256).nullable(),
+    gclid: z.string().max(512).nullable(),
+    referrer: z.string().max(2048).nullable(),
+    landingPath: z.string().max(512).nullable(),
+  }),
+  client: z.object({
+    viewport: z.enum(['mobile', 'tablet', 'desktop']).nullable(),
+    screenWidth: z.number().int().min(0).max(20000).nullable(),
+    timezone: z.string().max(128).nullable(),
+    language: z.string().max(64).nullable(),
+    userAgent: z.string().max(1024).nullable(),
+  }),
+})
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let raw: string
+  try {
+    raw = await request.text()
+  } catch {
+    return new NextResponse(null, { status: 204 })
+  }
+
+  if (raw.length > MAX_BODY_BYTES) {
+    console.warn('Audit progress payload too large; dropping', {
+      bytes: raw.length,
+    })
+    return new NextResponse(null, { status: 204 })
+  }
+
+  let parsedJson: unknown
+  try {
+    parsedJson = JSON.parse(raw)
+  } catch {
+    return new NextResponse(null, { status: 204 })
+  }
+
+  const parsed = payloadSchema.safeParse(parsedJson)
+  if (!parsed.success) {
+    console.warn('Invalid audit progress payload', parsed.error.flatten())
+    return new NextResponse(null, { status: 204 })
+  }
+
+  // Trust the request header over anything the client claims about itself.
+  // Shape mirrors `AuditProgressPayload` in src/lib/audit/progress-payload.ts;
+  // the schema above is the enforcement point, so keep the two in step.
+  const payload = {
+    ...parsed.data,
+    client: {
+      ...parsed.data.client,
+      userAgent: request.headers.get('user-agent')?.slice(0, 1024) ?? null,
+    },
+  }
+
+  const target = resolvePortalTarget(
+    PORTAL_PATHS.auditResponses,
+    process.env.AUDIT_INTAKE_TOKEN
+  )
+
+  if (!target) {
+    // Dev affordance: log rather than silently drop, so the whole flow is
+    // verifiable locally with no portal running.
+    console.info(
+      'PORTAL_API_BASE_URL/AUDIT_INTAKE_TOKEN not set; audit progress not forwarded',
+      JSON.stringify(payload, null, 2)
+    )
+    return new NextResponse(null, { status: 204 })
+  }
+
+  await postToPortal(target, payload, {
+    sessionId: payload.sessionId,
+    auditStatus: payload.status,
+    trigger: payload.trigger,
+  })
+
+  // The visitor's experience never depends on the portal being reachable.
+  return new NextResponse(null, { status: 204 })
+}

--- a/docs/prds/005-form-submissions/README.md
+++ b/docs/prds/005-form-submissions/README.md
@@ -1,0 +1,108 @@
+# 005 — Marketing form submissions to the portal
+
+## Why
+
+Both marketing forms used to POST to the portal's `/api/integrations/leads-intake`, creating a row in
+the `leads` table on final submit only. That meant:
+
+- everyone who abandoned the Opportunity Audit mid-wizard was invisible
+- the scored audit result was flattened into a free-text `message` field and could not be queried
+- no UTM attribution or PostHog linkage was captured for either form
+
+Now every audit attempt is pushed as it progresses, both forms land in the portal's `form_submissions`
+table, and leads are promoted from **Sales → Submissions** by hand. The `leads-intake` POST is gone from
+both actions.
+
+## What was built
+
+| File | Role |
+|---|---|
+| `src/lib/forms/context.ts` | Shared envelope: UTM/referrer, device/locale, PostHog ids, UUID minting |
+| `src/lib/forms/portal.ts` | Server-only endpoint resolution and best-effort POST. Holds the tokens |
+| `src/lib/forms/contact-payload.ts` | Contact wire contract and builder |
+| `src/lib/audit/session.ts` | Audit session identity, localStorage persistence, TTL, resume gate |
+| `src/lib/audit/progress-payload.ts` | Audit wire contract and builder |
+| `src/lib/audit/track-progress.ts` | Browser transport: `sendBeacon`, or `fetch` with `keepalive` |
+| `app/api/audit-progress/route.ts` | Same-origin proxy. Validates, injects user agent, forwards |
+| `src/hooks/use-audit.ts` | Orchestrates the audit session and its pushes |
+| `src/lib/audit/summarize-answers.ts` | `describeAnswers()` resolves option ids to labels, shared with the emails |
+
+### Why the audit needs a proxy route and contact does not
+
+`navigator.sendBeacon` cannot set request headers, so it can never carry the bearer token, and shipping
+the token to the browser would publish a portal secret in the JS bundle. The audit therefore beacons to
+a same-origin marketing route, which adds the token server-side:
+
+```
+browser ──sendBeacon──▶ marketing /api/audit-progress ──fetch + Bearer──▶ portal
+```
+
+The contact form is already a server action, so it posts to the portal directly. Its client half only
+gathers the browser-side context (PostHog ids, UTM params, screen metrics) and hands it to the action.
+
+Both paths set `client.userAgent` from the incoming request header rather than `navigator.userAgent`.
+
+### When the audit pushes
+
+| Trigger | Status | Fired from |
+|---|---|---|
+| `started` | `in_progress` | `start()` |
+| `step_completed` | `in_progress` | `completeStep()`, once per wizard section |
+| `scored` | `completed` | `submit()`, after the engine runs |
+| `captured` | `captured` | `markCaptured()`, after the email form succeeds |
+| `abandoned` | `abandoned` | `reset()`, only when leaving from the wizard |
+| `pagehide` | `in_progress` | Beacon on tab close, only if answers changed since the last push |
+
+`pagehide` deliberately does not claim `abandoned`: a tab switch is indistinguishable from a close. The
+portal infers real abandonment from `in_progress` plus a stale `updatedAt`.
+
+### Sender obligations, and how they are met
+
+The contract names three things the portal cannot do for us:
+
+1. **Stable `sessionId` for the whole session.** Minted once in `createAuditSession()` and persisted to
+   `localStorage` under `pts_audit_session_v1`. A refresh restores the same id, so resuming updates one
+   row rather than creating a second.
+2. **Monotonically increasing `updatedAt`.** Stamped in `commit()` at the moment of the change, which is
+   immediately before the push. Never taken from render state.
+3. **`responses` is always the full question set.** `describeAnswers()` maps over all of `QUESTIONS`, not
+   just the answered ones, emitting `value: null` for the rest.
+
+### Resume
+
+The session is mirrored to `localStorage` on every answer. On mount the hook restores it if the status is
+`in_progress`, it has at least one answer, and it is under the 7 day TTL. Reading it through
+`useSyncExternalStore` with a null server snapshot is what lets a client-only value participate in the
+server-rendered tree without a hydration mismatch.
+
+## Environment
+
+| Variable | Purpose |
+|---|---|
+| `PORTAL_API_BASE_URL` | Portal host, e.g. `https://portal.placetostandagency.com`. Paths are appended |
+| `AUDIT_INTAKE_TOKEN` | Bearer token for `/api/integrations/audit-responses` |
+| `CONTACT_INTAKE_TOKEN` | Bearer token for `/api/integrations/contact-submissions` |
+
+`PORTAL_LEADS_ENDPOINT` and `PORTAL_LEADS_TOKEN` are no longer read by any code and should be removed
+from Vercel after the cutover.
+
+Leave all three unset in local development. Both paths then log the payload to the server console
+instead of forwarding it, so the whole flow is verifiable with no portal running.
+
+## Failure handling
+
+Delivery is best-effort throughout. A portal outage logs and continues, and the visitor still sees
+success. The Resend emails and the audience opt-in are untouched by this integration and still gate
+success as they did before.
+
+## Known limitations
+
+- **UTM attribution is last-touch at collection time.** The params are read from the URL when the audit
+  starts or the contact form is submitted. Someone who lands on `/?utm_source=x` and then navigates
+  before converting arrives with a bare URL and loses their attribution. Site-wide first-touch capture is
+  a separate change.
+- **No consent gate.** Submissions are captured for anonymous visitors with no opt-in prompt, matching
+  how PostHog already behaves on this site. `app/privacy/page.tsx` does not currently describe this
+  collection.
+- **Beacons are unacknowledged.** A `pagehide` push the browser drops is simply lost; there is no retry.
+  The next push recovers the state, but a true tab-close has no next push.

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,9 +1,28 @@
 import { initBotId } from 'botid/client/core'
 
+/**
+ * Protect only the routes whose server actions actually call `checkBotId()`.
+ *
+ * Server actions POST to the URL of the page that invoked them, so these paths
+ * cover the contact form (`/contact`) and the audit's lead-capture form
+ * (`/audit`). A blanket `path: '/**'` also challenged every audit progress push
+ * to `/api/audit-progress`, which adds latency to each one and errors outright
+ * in local development, where the challenge cannot be served.
+ *
+ * If either form is ever rendered on another route, add that route here or its
+ * bot protection silently lapses.
+ */
 initBotId({
   protect: [
     {
-      path: '/**',
+      path: '/contact',
+      method: 'POST',
+      advancedOptions: {
+        checkLevel: 'basic',
+      },
+    },
+    {
+      path: '/audit',
       method: 'POST',
       advancedOptions: {
         checkLevel: 'basic',

--- a/src/components/audit/audit-app.tsx
+++ b/src/components/audit/audit-app.tsx
@@ -7,11 +7,31 @@ import { useAudit } from '@/src/hooks/use-audit'
 
 /** Top-level state machine for the audit: intro to wizard to results. */
 export function AuditApp() {
-  const { stage, answers, result, isScoring, setAnswer, start, submit, reset } =
-    useAudit()
+  const {
+    stage,
+    answers,
+    result,
+    isScoring,
+    initialStepIndex,
+    sessionId,
+    setAnswer,
+    start,
+    completeStep,
+    submit,
+    markCaptured,
+    reset,
+  } = useAudit()
 
   if (stage === 'results' && result) {
-    return <ResultsView result={result} answers={answers} onRestart={reset} />
+    return (
+      <ResultsView
+        result={result}
+        answers={answers}
+        auditSessionId={sessionId}
+        onCaptured={markCaptured}
+        onRestart={reset}
+      />
+    )
   }
 
   if (stage === 'wizard') {
@@ -19,7 +39,9 @@ export function AuditApp() {
       <AuditWizard
         answers={answers}
         isScoring={isScoring}
+        initialStepIndex={initialStepIndex}
         onAnswer={setAnswer}
+        onStepComplete={completeStep}
         onSubmit={submit}
         onExit={reset}
       />

--- a/src/components/audit/audit-landing.tsx
+++ b/src/components/audit/audit-landing.tsx
@@ -314,6 +314,9 @@ export function AuditLandingContent({ onStart }: AuditLandingProps) {
                     src={member.image}
                     alt={member.name}
                     fill
+                    // The avatar is a fixed 48px at every breakpoint, so this is
+                    // exact rather than a viewport estimate.
+                    sizes='48px'
                     className='object-cover'
                   />
                 </div>

--- a/src/components/audit/audit-wizard.tsx
+++ b/src/components/audit/audit-wizard.tsx
@@ -14,7 +14,10 @@ import type { AnswerValue, AuditAnswers } from '@/src/lib/audit/types'
 interface AuditWizardProps {
   answers: AuditAnswers
   isScoring: boolean
+  /** Where to open, non-zero when resuming a stored session. */
+  initialStepIndex?: number
   onAnswer: (questionId: string, value: AnswerValue) => void
+  onStepComplete: (stepIndex: number) => void
   onSubmit: () => void
   onExit: () => void
 }
@@ -23,12 +26,16 @@ interface AuditWizardProps {
 export function AuditWizard({
   answers,
   isScoring,
+  initialStepIndex = 0,
   onAnswer,
+  onStepComplete,
   onSubmit,
   onExit,
 }: AuditWizardProps) {
   const posthog = usePostHog()
-  const [stepIndex, setStepIndex] = useState(0)
+  const [stepIndex, setStepIndex] = useState(() =>
+    Math.min(Math.max(initialStepIndex, 0), SECTIONS.length - 1)
+  )
   const [showErrors, setShowErrors] = useState(false)
 
   const section = SECTIONS[stepIndex]
@@ -53,6 +60,7 @@ export function AuditWizard({
       step: stepIndex + 1,
       section: section.id,
     })
+    onStepComplete(stepIndex)
     if (isLastStep) {
       onSubmit()
     } else {

--- a/src/components/audit/results-view.tsx
+++ b/src/components/audit/results-view.tsx
@@ -34,11 +34,15 @@ import {
   type AuditLeadValues,
 } from '@/src/lib/validations/audit'
 import { sendAudit, type AuditActionResult } from '@/app/actions/send-audit'
+import type { AuditLeadPayload } from '@/src/lib/audit/progress-payload'
 import type { AuditAnswers, AuditResult, PhaseId } from '@/src/lib/audit/types'
 
 interface ResultsViewProps {
   result: AuditResult
   answers: AuditAnswers
+  /** Ties the lead back to the stored audit response row in the portal. */
+  auditSessionId: string | null
+  onCaptured: (lead: AuditLeadPayload) => void
   onRestart: () => void
 }
 
@@ -61,7 +65,13 @@ function shortPhaseName(id: PhaseId): string {
   return PHASES[id].name.split(' & ')[0]
 }
 
-export function ResultsView({ result, answers, onRestart }: ResultsViewProps) {
+export function ResultsView({
+  result,
+  answers,
+  auditSessionId,
+  onCaptured,
+  onRestart,
+}: ResultsViewProps) {
   const posthog = usePostHog()
   const { phase, phaseScores, recommendations } = result
   const maxScore = Math.max(1, ...Object.values(phaseScores))
@@ -279,7 +289,12 @@ export function ResultsView({ result, answers, onRestart }: ResultsViewProps) {
       )}
 
       {/* Capture / CTA */}
-      <CaptureForm result={result} answers={answers} />
+      <CaptureForm
+        result={result}
+        answers={answers}
+        auditSessionId={auditSessionId}
+        onCaptured={onCaptured}
+      />
     </div>
   )
 }
@@ -287,10 +302,17 @@ export function ResultsView({ result, answers, onRestart }: ResultsViewProps) {
 interface CaptureFormProps {
   result: AuditResult
   answers: AuditAnswers
+  auditSessionId: string | null
+  onCaptured: (lead: AuditLeadPayload) => void
 }
 
 /** Emails the respondent their result and hands us the lead. */
-function CaptureForm({ result, answers }: CaptureFormProps) {
+function CaptureForm({
+  result,
+  answers,
+  auditSessionId,
+  onCaptured,
+}: CaptureFormProps) {
   const posthog = usePostHog()
   const [isPending, startTransition] = useTransition()
   const [isSuccess, setIsSuccess] = useState(false)
@@ -306,32 +328,40 @@ function CaptureForm({ result, answers }: CaptureFormProps) {
 
   const onSubmit = form.handleSubmit(values => {
     startTransition(() => {
-      void sendAudit(values, result, answers).then((res: AuditActionResult) => {
-        if (!res.success) {
-          if (res.errors) {
-            Object.entries(res.errors).forEach(([key, messages]) => {
-              const typedMessages = messages as string[] | undefined
-              const firstMessage = typedMessages?.[0]
-              if (firstMessage) {
-                form.setError(key as keyof AuditLeadValues, {
-                  message: firstMessage,
-                })
-              }
+      void sendAudit(values, result, answers, auditSessionId).then(
+        (res: AuditActionResult) => {
+          if (!res.success) {
+            if (res.errors) {
+              Object.entries(res.errors).forEach(([key, messages]) => {
+                const typedMessages = messages as string[] | undefined
+                const firstMessage = typedMessages?.[0]
+                if (firstMessage) {
+                  form.setError(key as keyof AuditLeadValues, {
+                    message: firstMessage,
+                  })
+                }
+              })
+            }
+
+            toast({
+              variant: 'destructive',
+              title: 'Something went wrong',
+              description: res.message ?? 'Please try again.',
             })
+            return
           }
 
-          toast({
-            variant: 'destructive',
-            title: 'Something went wrong',
-            description: res.message ?? 'Please try again.',
+          form.reset()
+          setIsSuccess(true)
+          posthog?.capture('audit_capture_submitted', { phase: result.phase.id })
+          onCaptured({
+            name: values.name.trim(),
+            email: values.email.trim(),
+            company: values.company?.trim() || null,
+            marketingConsent: values.marketingConsent ?? false,
           })
-          return
         }
-
-        form.reset()
-        setIsSuccess(true)
-        posthog?.capture('audit_capture_submitted', { phase: result.phase.id })
-      })
+      )
     })
   })
 

--- a/src/components/sections/contact-section.tsx
+++ b/src/components/sections/contact-section.tsx
@@ -21,11 +21,20 @@ import {
   contactSchema,
   type ContactFormValues,
 } from '@/src/lib/validations/contact'
+import {
+  collectSubmissionContext,
+  createSubmissionId,
+  readSubmissionAnalytics,
+} from '@/src/lib/forms/context'
+import type { ContactSubmissionContext } from '@/src/lib/forms/contact-payload'
 
 export function ContactSection() {
   const posthog = usePostHog()
   const [isPending, startTransition] = useTransition()
   const [isSuccess, setIsSuccess] = useState(false)
+  // Minted on first submit and kept, so retrying a failed submit upserts the
+  // same portal row instead of creating a duplicate.
+  const [submissionId, setSubmissionId] = useState<string | null>(null)
   const form = useForm<ContactFormValues>({
     resolver: zodResolver(contactSchema),
     defaultValues: {
@@ -39,33 +48,46 @@ export function ContactSection() {
   })
 
   const onSubmit = form.handleSubmit(values => {
+    const id = submissionId ?? createSubmissionId()
+    if (!submissionId) setSubmissionId(id)
+
+    const { attribution, client } = collectSubmissionContext()
+    const submissionContext: ContactSubmissionContext = {
+      submissionId: id,
+      analytics: readSubmissionAnalytics(),
+      attribution,
+      client,
+    }
+
     startTransition(() => {
-      void sendContact(values).then((result: ContactActionResult) => {
-        if (!result.success) {
-          if (result.errors) {
-            Object.entries(result.errors).forEach(([key, messages]) => {
-              const typedMessages = messages as string[] | undefined
-              const firstMessage = typedMessages?.[0]
-              if (firstMessage) {
-                form.setError(key as keyof ContactFormValues, {
-                  message: firstMessage,
-                })
-              }
+      void sendContact(values, submissionContext).then(
+        (result: ContactActionResult) => {
+          if (!result.success) {
+            if (result.errors) {
+              Object.entries(result.errors).forEach(([key, messages]) => {
+                const typedMessages = messages as string[] | undefined
+                const firstMessage = typedMessages?.[0]
+                if (firstMessage) {
+                  form.setError(key as keyof ContactFormValues, {
+                    message: firstMessage,
+                  })
+                }
+              })
+            }
+
+            toast({
+              variant: 'destructive',
+              title: 'Something went wrong',
+              description: result.message ?? 'Please try again.',
             })
+            return
           }
 
-          toast({
-            variant: 'destructive',
-            title: 'Something went wrong',
-            description: result.message ?? 'Please try again.',
-          })
-          return
+          form.reset()
+          setIsSuccess(true)
+          posthog?.capture('contact_form_submitted')
         }
-
-        form.reset()
-        setIsSuccess(true)
-        posthog?.capture('contact_form_submitted')
-      })
+      )
     })
   })
 

--- a/src/hooks/use-audit.ts
+++ b/src/hooks/use-audit.ts
@@ -1,8 +1,31 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 import { usePostHog } from 'posthog-js/react'
 import { runAudit } from '@/src/lib/audit/engine'
+import { SECTIONS } from '@/src/lib/audit/questions'
+import {
+  buildAuditProgressPayload,
+  type AuditLeadPayload,
+  type AuditTrigger,
+} from '@/src/lib/audit/progress-payload'
+import {
+  createAuditSession,
+  getAuditSessionServerSnapshot,
+  getAuditSessionSnapshot,
+  isResumable,
+  setAuditSession,
+  subscribeToAuditSession,
+  type AuditSession,
+  type AuditStatus,
+} from '@/src/lib/audit/session'
+import { sendAuditProgress } from '@/src/lib/audit/track-progress'
 import type {
   AnswerValue,
   AuditAnswers,
@@ -11,14 +34,22 @@ import type {
 
 export type AuditStage = 'intro' | 'wizard' | 'results'
 
+/** Stable identity so consumers do not see a new object every render. */
+const EMPTY_ANSWERS: AuditAnswers = {}
+
 export interface UseAudit {
   stage: AuditStage
   answers: AuditAnswers
   result: AuditResult | null
   isScoring: boolean
+  /** Wizard step to open on, non-zero when resuming a stored session. */
+  initialStepIndex: number
+  sessionId: string | null
   setAnswer: (questionId: string, value: AnswerValue) => void
   start: () => void
+  completeStep: (stepIndex: number) => void
   submit: () => Promise<void>
+  markCaptured: (lead: AuditLeadPayload) => void
   reset: () => void
 }
 
@@ -26,66 +57,240 @@ export interface UseAudit {
  * Owns the audit's client state: the answers, which stage of the flow we're in,
  * and the scored result. Scoring goes through `runAudit`, which is async today
  * only so a future Claude-backed engine drops in without touching this hook.
+ *
+ * The session (see `lib/audit/session.ts`) is the single source of truth for
+ * answers. It is mirrored to localStorage on every change so a refresh resumes,
+ * and pushed to the portal at each section boundary so partial audits are
+ * captured rather than lost. Every push is best-effort and never blocks the UI.
  */
 export function useAudit(): UseAudit {
   const posthog = usePostHog()
-  const [stage, setStage] = useState<AuditStage>('intro')
-  const [answers, setAnswers] = useState<AuditAnswers>({})
+  const session = useSyncExternalStore(
+    subscribeToAuditSession,
+    getAuditSessionSnapshot,
+    getAuditSessionServerSnapshot
+  )
+
+  // Null means "wherever the stored session says". Once the visitor acts, this
+  // takes over. Deriving the stage rather than storing it is what lets a resumed
+  // session land straight in the wizard without a state update after hydration.
+  const [chosenStage, setChosenStage] = useState<AuditStage | null>(null)
   const [result, setResult] = useState<AuditResult | null>(null)
   const [isScoring, setIsScoring] = useState(false)
 
+  const stage: AuditStage =
+    chosenStage ?? (isResumable(session) ? 'wizard' : 'intro')
+
+  const completedAtRef = useRef<string | null>(null)
+  /** True when answers changed since the last push, so pagehide can skip. */
+  const dirtyRef = useRef(false)
+
+  const push = useCallback(
+    (args: {
+      session: AuditSession
+      status: AuditStatus
+      trigger: AuditTrigger
+      result?: AuditResult | null
+      lead?: AuditLeadPayload | null
+      beacon?: boolean
+    }) => {
+      sendAuditProgress(
+        buildAuditProgressPayload({
+          session: args.session,
+          status: args.status,
+          trigger: args.trigger,
+          result: args.result ?? null,
+          lead: args.lead ?? null,
+          completedAt: completedAtRef.current,
+        }),
+        { beacon: args.beacon }
+      )
+    },
+    []
+  )
+
+  /** Apply a change to the session, stamp it, persist it, and return it. */
+  const commit = useCallback(
+    (updater: (prev: AuditSession) => AuditSession): AuditSession | null => {
+      const prev = getAuditSessionSnapshot()
+      if (!prev) return null
+
+      const next: AuditSession = {
+        ...updater(prev),
+        updatedAt: new Date().toISOString(),
+      }
+      setAuditSession(next)
+      return next
+    },
+    []
+  )
+
+  // Report a resume once, reading the store directly so this never depends on
+  // render state. The ref keeps it to a single event even as PostHog attaches.
+  const resumeReportedRef = useRef(false)
+  useEffect(() => {
+    if (resumeReportedRef.current) return
+
+    const stored = getAuditSessionSnapshot()
+    if (!isResumable(stored) || !stored) return
+
+    resumeReportedRef.current = true
+    posthog?.capture('audit_resumed', {
+      step: Math.min(stored.stepIndex, SECTIONS.length - 1) + 1,
+      answers_count: Object.keys(stored.answers).length,
+    })
+  }, [posthog])
+
   const setAnswer = useCallback(
     (questionId: string, value: AnswerValue) => {
-      setAnswers(prev => ({ ...prev, [questionId]: value }))
+      commit(prev => ({
+        ...prev,
+        answers: { ...prev.answers, [questionId]: value },
+      }))
+      dirtyRef.current = true
       posthog?.capture('audit_answer_selected', {
         question_id: questionId,
         value,
       })
     },
-    [posthog]
+    [commit, posthog]
   )
 
   const start = useCallback(() => {
-    setAnswers({})
+    const fresh = createAuditSession()
+    setAuditSession(fresh)
+
     setResult(null)
-    setStage('wizard')
+    completedAtRef.current = null
+    dirtyRef.current = false
+    // A fresh session is never resumable, so pin the stage explicitly.
+    setChosenStage('wizard')
+
     posthog?.capture('audit_started')
-  }, [posthog])
+    push({ session: fresh, status: 'in_progress', trigger: 'started' })
+  }, [posthog, push])
+
+  const completeStep = useCallback(
+    (stepIndex: number) => {
+      const next = commit(prev => ({
+        ...prev,
+        // Track the furthest point reached, so stepping back and forward again
+        // never loses ground.
+        stepIndex: Math.min(
+          Math.max(prev.stepIndex, stepIndex + 1),
+          SECTIONS.length - 1
+        ),
+      }))
+      if (!next) return
+
+      dirtyRef.current = false
+      push({ session: next, status: 'in_progress', trigger: 'step_completed' })
+    },
+    [commit, push]
+  )
 
   const submit = useCallback(async () => {
     setIsScoring(true)
     try {
-      const scored = await runAudit(answers)
+      const scored = await runAudit(getAuditSessionSnapshot()?.answers ?? {})
       setResult(scored)
-      setStage('results')
+      setChosenStage('results')
       posthog?.capture('audit_completed', {
         phase: scored.phase.id,
         top_service: scored.recommendations[0]?.service.id,
       })
+
+      completedAtRef.current = new Date().toISOString()
+      const next = commit(prev => ({ ...prev, status: 'completed' }))
+      dirtyRef.current = false
+      if (next) {
+        push({
+          session: next,
+          status: 'completed',
+          trigger: 'scored',
+          result: scored,
+        })
+      }
     } finally {
       setIsScoring(false)
     }
-  }, [answers, posthog])
+  }, [posthog, commit, push])
+
+  const markCaptured = useCallback(
+    (lead: AuditLeadPayload) => {
+      const next = commit(prev => ({ ...prev, status: 'captured' }))
+      if (!next) return
+
+      push({
+        session: next,
+        status: 'captured',
+        trigger: 'captured',
+        result,
+        lead,
+      })
+    },
+    [commit, push, result]
+  )
 
   const reset = useCallback(() => {
-    if (stage === 'wizard') {
+    const current = getAuditSessionSnapshot()
+
+    if (stage === 'wizard' && current) {
       posthog?.capture('audit_abandoned', {
-        answers_count: Object.keys(answers).length,
+        answers_count: Object.keys(current.answers).length,
+      })
+      // Stamped at send time, not reused from the last commit: `updatedAt` is
+      // the portal's ordering key and a repeat value risks being treated as
+      // stale against the push that already carried it.
+      push({
+        session: { ...current, updatedAt: new Date().toISOString() },
+        status: 'abandoned',
+        trigger: 'abandoned',
       })
     }
-    setAnswers({})
+
+    setAuditSession(null)
     setResult(null)
-    setStage('intro')
-  }, [stage, answers, posthog])
+    completedAtRef.current = null
+    dirtyRef.current = false
+    setChosenStage('intro')
+  }, [stage, posthog, push])
+
+  // Catch the mid-section drop-off that no other trigger sees. Reported as
+  // `in_progress`, not `abandoned`: a tab switch is indistinguishable from a
+  // close, so the portal infers abandonment from staleness instead.
+  useEffect(() => {
+    if (stage !== 'wizard') return
+
+    const handlePageHide = () => {
+      const current = getAuditSessionSnapshot()
+      if (!current || !dirtyRef.current) return
+
+      dirtyRef.current = false
+      push({
+        session: { ...current, updatedAt: new Date().toISOString() },
+        status: 'in_progress',
+        trigger: 'pagehide',
+        beacon: true,
+      })
+    }
+
+    window.addEventListener('pagehide', handlePageHide)
+    return () => window.removeEventListener('pagehide', handlePageHide)
+  }, [stage, push])
 
   return {
     stage,
-    answers,
+    answers: session?.answers ?? EMPTY_ANSWERS,
     result,
     isScoring,
+    initialStepIndex: Math.min(session?.stepIndex ?? 0, SECTIONS.length - 1),
+    sessionId: session?.sessionId ?? null,
     setAnswer,
     start,
+    completeStep,
     submit,
+    markCaptured,
     reset,
   }
 }

--- a/src/lib/audit/progress-payload.ts
+++ b/src/lib/audit/progress-payload.ts
@@ -1,0 +1,172 @@
+/**
+ * Builds the payload the marketing site sends to the portal for every audit
+ * attempt, finished or not.
+ *
+ * This is the authoritative shape of the contract. The portal upserts on
+ * `sessionId`, so the same attempt can be pushed repeatedly as it progresses.
+ * Keep this file and the portal's intake schema in step: see
+ * `docs/prds/005-form-submissions/README.md`.
+ *
+ * Pure and side-effect free apart from reading PostHog ids off the browser
+ * client via `readSubmissionAnalytics`, which yields nulls rather than throwing
+ * when PostHog is disabled (as it is in local dev).
+ */
+import { QUESTIONS, SECTIONS } from '@/src/lib/audit/questions'
+import { describeAnswers } from '@/src/lib/audit/summarize-answers'
+import { readSubmissionAnalytics } from '@/src/lib/forms/context'
+import type {
+  SubmissionAnalytics,
+  SubmissionAttribution,
+  SubmissionClientInfo,
+} from '@/src/lib/forms/context'
+import type { AuditSession, AuditStatus } from '@/src/lib/audit/session'
+import type {
+  AuditResult,
+  PhaseId,
+  QuestionType,
+  ServiceId,
+} from '@/src/lib/audit/types'
+
+export const AUDIT_SOURCE_DETAIL = 'https://placetostandagency.com/audit'
+
+export type { AuditStatus }
+
+/** Why this particular push happened. */
+export type AuditTrigger =
+  | 'started'
+  | 'step_completed'
+  | 'scored'
+  | 'captured'
+  | 'abandoned'
+  | 'pagehide'
+
+export interface AuditResponseItem {
+  questionId: string
+  sectionId: string
+  prompt: string
+  type: QuestionType
+  value: string | string[] | null
+  labels: string[]
+}
+
+export interface AuditProgressSummary {
+  furthestStepIndex: number
+  stepsTotal: number
+  answeredCount: number
+  questionsTotal: number
+  percentComplete: number
+  durationMs: number
+}
+
+export interface AuditResultPayload {
+  phaseId: PhaseId
+  phaseName: string
+  summary: string
+  generatedBy: 'rules' | 'ai'
+  phaseScores: Record<PhaseId, number>
+  recommendations: Array<{
+    serviceId: ServiceId
+    serviceName: string
+    score: number
+    reasons: string[]
+  }>
+}
+
+export interface AuditLeadPayload {
+  name: string
+  email: string
+  company: string | null
+  marketingConsent: boolean
+}
+
+export interface AuditProgressPayload {
+  sessionId: string
+  status: AuditStatus
+  trigger: AuditTrigger
+  sourceDetail: string
+  startedAt: string
+  updatedAt: string
+  completedAt: string | null
+  progress: AuditProgressSummary
+  responses: AuditResponseItem[]
+  result: AuditResultPayload | null
+  lead: AuditLeadPayload | null
+  analytics: SubmissionAnalytics
+  attribution: SubmissionAttribution
+  client: SubmissionClientInfo & { userAgent: string | null }
+}
+
+interface BuildArgs {
+  /** The session as it stands right now, answers and step included. */
+  session: AuditSession
+  status: AuditStatus
+  trigger: AuditTrigger
+  result?: AuditResult | null
+  lead?: AuditLeadPayload | null
+  completedAt?: string | null
+}
+
+function toResultPayload(result: AuditResult): AuditResultPayload {
+  return {
+    phaseId: result.phase.id,
+    phaseName: result.phase.name,
+    summary: result.summary,
+    generatedBy: result.generatedBy,
+    phaseScores: result.phaseScores,
+    recommendations: result.recommendations.map(rec => ({
+      serviceId: rec.service.id,
+      serviceName: rec.service.name,
+      score: rec.score,
+      reasons: rec.reasons,
+    })),
+  }
+}
+
+export function buildAuditProgressPayload({
+  session,
+  status,
+  trigger,
+  result = null,
+  lead = null,
+  completedAt = null,
+}: BuildArgs): AuditProgressPayload {
+  const responses = describeAnswers(session.answers)
+  const answeredCount = responses.filter(item => item.labels.length > 0).length
+  const questionsTotal = QUESTIONS.length
+
+  const startedMs = new Date(session.startedAt).getTime()
+  const updatedMs = new Date(session.updatedAt).getTime()
+  const durationMs =
+    Number.isFinite(startedMs) && Number.isFinite(updatedMs)
+      ? Math.max(0, updatedMs - startedMs)
+      : 0
+
+  return {
+    sessionId: session.sessionId,
+    status,
+    trigger,
+    sourceDetail: AUDIT_SOURCE_DETAIL,
+    startedAt: session.startedAt,
+    updatedAt: session.updatedAt,
+    completedAt,
+    progress: {
+      furthestStepIndex: session.stepIndex,
+      stepsTotal: SECTIONS.length,
+      answeredCount,
+      questionsTotal,
+      percentComplete:
+        questionsTotal > 0
+          ? Math.round((answeredCount / questionsTotal) * 100)
+          : 0,
+      durationMs,
+    },
+    responses,
+    result: result ? toResultPayload(result) : null,
+    lead,
+    analytics: readSubmissionAnalytics(),
+    attribution: session.context.attribution,
+    // `userAgent` is filled in server-side by the API route, which reads the
+    // request header rather than trusting the client.
+    client: { ...session.context.client, userAgent: null },
+  }
+}

--- a/src/lib/audit/session.ts
+++ b/src/lib/audit/session.ts
@@ -1,0 +1,179 @@
+/**
+ * Client-side identity and persistence for an audit attempt.
+ *
+ * The audit used to be entirely ephemeral: a refresh wiped every answer and
+ * nobody who abandoned mid-wizard left a trace. This module gives each attempt a
+ * stable `sessionId` and mirrors progress into localStorage, so (a) a refresh
+ * resumes where the visitor left off and (b) every progress push to the portal
+ * updates the same row instead of creating duplicates.
+ *
+ * Every storage call is defensive. Safari private mode throws on `setItem`, and
+ * a storage failure must never break the audit itself.
+ */
+import {
+  collectSubmissionContext,
+  createSubmissionId,
+  type SubmissionContext,
+} from '@/src/lib/forms/context'
+import type { AuditAnswers } from './types'
+
+export const AUDIT_SESSION_KEY = 'pts_audit_session_v1'
+
+/** Stored sessions older than this are discarded rather than resumed. */
+export const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * How far the attempt got. Also the resume gate: only `in_progress` sessions are
+ * restored, so finishing the audit and coming back later starts a fresh one.
+ * The portal only ever advances a row along this order, never backwards.
+ */
+export type AuditStatus = 'in_progress' | 'completed' | 'captured' | 'abandoned'
+
+export interface AuditSession {
+  sessionId: string
+  status: AuditStatus
+  answers: AuditAnswers
+  /** Furthest wizard step reached, 0-based. Doubles as the resume point. */
+  stepIndex: number
+  startedAt: string
+  updatedAt: string
+  /** Captured once when the session is created, then frozen for its lifetime. */
+  context: SubmissionContext
+}
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined'
+}
+
+/** Mint a fresh session anchored to right now. */
+export function createAuditSession(): AuditSession {
+  const now = new Date().toISOString()
+  return {
+    sessionId: createSubmissionId(),
+    status: 'in_progress',
+    answers: {},
+    stepIndex: 0,
+    startedAt: now,
+    updatedAt: now,
+    context: collectSubmissionContext(),
+  }
+}
+
+function isUsableSession(value: unknown): value is AuditSession {
+  if (!value || typeof value !== 'object') return false
+  const session = value as Partial<AuditSession>
+  return (
+    typeof session.sessionId === 'string' &&
+    typeof session.startedAt === 'string' &&
+    typeof session.updatedAt === 'string' &&
+    typeof session.answers === 'object' &&
+    session.answers !== null &&
+    typeof session.context === 'object' &&
+    session.context !== null
+  )
+}
+
+/** The stored session, or null when absent, unreadable, or past the TTL. */
+function readStoredSession(): AuditSession | null {
+  if (!isBrowser()) return null
+
+  try {
+    const raw = window.localStorage.getItem(AUDIT_SESSION_KEY)
+    if (!raw) return null
+
+    const parsed: unknown = JSON.parse(raw)
+    if (!isUsableSession(parsed)) return null
+
+    const age = Date.now() - new Date(parsed.updatedAt).getTime()
+    if (!Number.isFinite(age) || age > SESSION_TTL_MS) {
+      removeStoredSession()
+      return null
+    }
+
+    return {
+      ...parsed,
+      status: parsed.status ?? 'in_progress',
+      stepIndex:
+        typeof parsed.stepIndex === 'number' && parsed.stepIndex >= 0
+          ? parsed.stepIndex
+          : 0,
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeStoredSession(session: AuditSession): void {
+  if (!isBrowser()) return
+
+  try {
+    window.localStorage.setItem(AUDIT_SESSION_KEY, JSON.stringify(session))
+  } catch {
+    // Private mode, quota exceeded, or storage disabled. The in-memory copy
+    // below still drives the UI, so the audit works. It just will not resume.
+  }
+}
+
+function removeStoredSession(): void {
+  if (!isBrowser()) return
+
+  try {
+    window.localStorage.removeItem(AUDIT_SESSION_KEY)
+  } catch {
+    // Nothing useful to do here.
+  }
+}
+
+/*
+ * The session is exposed as an external store so React can read it with
+ * `useSyncExternalStore`. That is what lets a client-only value participate in
+ * a server-rendered tree: the server snapshot is always null, so the first
+ * client render matches the server HTML, and React re-renders with the restored
+ * session immediately after hydration.
+ *
+ * `memorySession` is the authority, mirrored out to localStorage. Keeping it in
+ * memory means a browser that refuses storage still gets a working audit.
+ */
+let memorySession: AuditSession | null | undefined
+const listeners = new Set<() => void>()
+
+export function subscribeToAuditSession(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** Referentially stable between writes, as `useSyncExternalStore` requires. */
+export function getAuditSessionSnapshot(): AuditSession | null {
+  if (memorySession === undefined) {
+    memorySession = readStoredSession()
+  }
+  return memorySession
+}
+
+export function getAuditSessionServerSnapshot(): AuditSession | null {
+  return null
+}
+
+/** Replace the session, mirror it to storage, and notify subscribers. */
+export function setAuditSession(session: AuditSession | null): void {
+  memorySession = session
+
+  if (session) {
+    writeStoredSession(session)
+  } else {
+    removeStoredSession()
+  }
+
+  listeners.forEach(listener => listener())
+}
+
+/** Whether a stored session is worth dropping someone back into. */
+export function isResumable(session: AuditSession | null): boolean {
+  return (
+    session !== null &&
+    session.status === 'in_progress' &&
+    Object.keys(session.answers).length > 0
+  )
+}

--- a/src/lib/audit/summarize-answers.ts
+++ b/src/lib/audit/summarize-answers.ts
@@ -1,12 +1,21 @@
 /**
- * Turn raw audit answers into readable question/answer pairs, grouped by section.
+ * Turn raw audit answers into readable question/answer pairs.
  *
- * Shared by the internal team email (HTML template + plain-text fallback) so the
- * team can review every response, not just the scored result. Option IDs are
- * resolved to their human labels via the QUESTIONS definitions.
+ * `describeAnswers` is the low-level view: every question in definition order,
+ * carrying both the raw option ids and their resolved human labels. The portal
+ * payload uses it so the receiving side needs no copy of the question set.
+ *
+ * `summarizeAnswers` groups the same data by section for the internal team email
+ * (HTML template + plain-text fallback), so the team can review every response,
+ * not just the scored result.
  */
 import { QUESTIONS, SECTIONS } from '@/src/lib/audit/questions'
-import type { AuditAnswers, AuditQuestion } from '@/src/lib/audit/types'
+import type {
+  AnswerValue,
+  AuditAnswers,
+  AuditQuestion,
+  QuestionType,
+} from '@/src/lib/audit/types'
 
 export interface AnswerItem {
   prompt: string
@@ -18,23 +27,67 @@ export interface AnswerGroup {
   items: AnswerItem[]
 }
 
+/** One question and its answer, in both machine and human form. */
+export interface DescribedAnswer {
+  questionId: string
+  sectionId: string
+  prompt: string
+  type: QuestionType
+  /** Raw option id(s) or free text. Null when the question is unanswered. */
+  value: AnswerValue | null
+  /** Human-readable labels for the selected options. Empty when unanswered. */
+  labels: string[]
+}
+
 const NO_ANSWER = 'No answer'
+
+/** Selected option ids as an array, regardless of single vs multi. */
+function selectedIds(value: AnswerValue | undefined): string[] {
+  if (Array.isArray(value)) return value
+  return value ? [value] : []
+}
+
+function resolveLabels(
+  question: AuditQuestion,
+  value: AnswerValue | undefined
+): string[] {
+  if (question.type === 'text') {
+    const text = typeof value === 'string' ? value.trim() : ''
+    return text ? [text] : []
+  }
+
+  return selectedIds(value).map(
+    id => question.options?.find(option => option.id === id)?.label ?? id
+  )
+}
 
 function displayAnswer(
   question: AuditQuestion,
-  value: AuditAnswers[string] | undefined
+  value: AnswerValue | undefined
 ): string {
-  if (question.type === 'text') {
-    const text = typeof value === 'string' ? value.trim() : ''
-    return text || NO_ANSWER
-  }
+  const labels = resolveLabels(question, value)
+  return labels.length > 0 ? labels.join(', ') : NO_ANSWER
+}
 
-  const ids = Array.isArray(value) ? value : value ? [value] : []
-  if (ids.length === 0) return NO_ANSWER
+/**
+ * Every question with its raw value and resolved labels, in definition order.
+ * Unanswered questions are included with `value: null` so a partial audit has
+ * the same shape as a completed one.
+ */
+export function describeAnswers(answers: AuditAnswers): DescribedAnswer[] {
+  return QUESTIONS.map(question => {
+    const raw = answers[question.id]
+    const labels = resolveLabels(question, raw)
 
-  return ids
-    .map(id => question.options?.find(option => option.id === id)?.label ?? id)
-    .join(', ')
+    return {
+      questionId: question.id,
+      sectionId: question.sectionId,
+      prompt: question.prompt,
+      type: question.type,
+      value: labels.length > 0 ? (raw ?? null) : null,
+      labels,
+    }
+  })
 }
 
 /** Every question with its answer, grouped by section, in definition order. */

--- a/src/lib/audit/track-progress.ts
+++ b/src/lib/audit/track-progress.ts
@@ -1,0 +1,57 @@
+/**
+ * One-way transport for audit progress. Never throws, never blocks the UI.
+ *
+ * Losing a progress push is always preferable to interrupting someone taking the
+ * audit, so every failure path here is a silent no-op.
+ */
+import type { AuditProgressPayload } from '@/src/lib/audit/progress-payload'
+
+export const AUDIT_PROGRESS_ENDPOINT = '/api/audit-progress'
+
+interface SendOptions {
+  /**
+   * Use `navigator.sendBeacon`, which survives the page unloading. Only correct
+   * for `pagehide`, since beacons cannot report failure and are not ordered
+   * against normal requests.
+   */
+  beacon?: boolean
+}
+
+export function sendAuditProgress(
+  payload: AuditProgressPayload,
+  { beacon = false }: SendOptions = {}
+): void {
+  if (typeof window === 'undefined') return
+
+  let body: string
+  try {
+    body = JSON.stringify(payload)
+  } catch {
+    return
+  }
+
+  if (beacon && typeof navigator.sendBeacon === 'function') {
+    try {
+      const blob = new Blob([body], { type: 'application/json' })
+      const queued = navigator.sendBeacon(AUDIT_PROGRESS_ENDPOINT, blob)
+      if (queued) return
+      // Beacon queue full or blocked. Fall through to the fetch below, which
+      // still has a chance thanks to `keepalive`.
+    } catch {
+      // Same fall-through.
+    }
+  }
+
+  try {
+    void fetch(AUDIT_PROGRESS_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {
+      // Offline, blocked by an extension, or the route is down. Not our problem.
+    })
+  } catch {
+    // Ditto.
+  }
+}

--- a/src/lib/forms/contact-payload.ts
+++ b/src/lib/forms/contact-payload.ts
@@ -1,0 +1,68 @@
+/**
+ * Wire contract for `POST /api/integrations/contact-submissions`.
+ *
+ * Shares the `analytics` / `attribution` / `client` envelope with the audit
+ * payload so both forms land in the portal's `form_submissions` table with the
+ * same shape. See `docs/prds/005-form-submissions/README.md`.
+ */
+import type {
+  SubmissionAnalytics,
+  SubmissionAttribution,
+  SubmissionClientInfo,
+} from '@/src/lib/forms/context'
+
+export const CONTACT_SOURCE_DETAIL = 'https://placetostandagency.com/'
+
+export interface ContactSubmissionFields {
+  name: string
+  email: string
+  company: string | null
+  website: string | null
+  message: string
+  marketingConsent: boolean
+}
+
+/**
+ * What the browser hands to the `sendContact` server action.
+ *
+ * The action cannot read any of this itself: PostHog ids, UTM params, and screen
+ * metrics only exist in the browser. `submissionId` is minted client-side and
+ * held for the lifetime of the form, so retrying a failed submit updates the
+ * same portal row rather than creating a second one.
+ */
+export interface ContactSubmissionContext {
+  submissionId: string
+  analytics: SubmissionAnalytics
+  attribution: SubmissionAttribution
+  client: SubmissionClientInfo
+}
+
+export interface ContactSubmissionPayload {
+  submissionId: string
+  sourceDetail: string
+  submittedAt: string
+  contact: ContactSubmissionFields
+  analytics: SubmissionAnalytics
+  attribution: SubmissionAttribution
+  client: SubmissionClientInfo & { userAgent: string | null }
+}
+
+export function buildContactSubmissionPayload({
+  context,
+  contact,
+  userAgent,
+}: {
+  context: ContactSubmissionContext
+  contact: ContactSubmissionFields
+  userAgent: string | null
+}): ContactSubmissionPayload {
+  return {
+    submissionId: context.submissionId,
+    sourceDetail: CONTACT_SOURCE_DETAIL,
+    submittedAt: new Date().toISOString(),
+    contact,
+    analytics: context.analytics,
+    attribution: context.attribution,
+    client: { ...context.client, userAgent },
+  }
+}

--- a/src/lib/forms/context.ts
+++ b/src/lib/forms/context.ts
@@ -1,0 +1,173 @@
+/**
+ * Campaign, session, and device context attached to every form submission.
+ *
+ * Shared by the Opportunity Audit and the contact form so both land in the
+ * portal's `form_submissions` table with an identical envelope. See
+ * `docs/prds/005-form-submissions/README.md` for the wire contract.
+ *
+ * Client-only: reads `window`, `document`, and the PostHog browser client.
+ */
+import posthog from 'posthog-js'
+
+export type ViewportClass = 'mobile' | 'tablet' | 'desktop'
+
+export interface SubmissionAttribution {
+  utmSource: string | null
+  utmMedium: string | null
+  utmCampaign: string | null
+  utmTerm: string | null
+  utmContent: string | null
+  gclid: string | null
+  referrer: string | null
+  landingPath: string | null
+}
+
+/** `userAgent` is filled in server-side from the request header, never here. */
+export interface SubmissionClientInfo {
+  viewport: ViewportClass | null
+  screenWidth: number | null
+  timezone: string | null
+  language: string | null
+}
+
+export interface SubmissionAnalytics {
+  posthogDistinctId: string | null
+  posthogSessionId: string | null
+  posthogReplayUrl: string | null
+}
+
+export interface SubmissionContext {
+  attribution: SubmissionAttribution
+  client: SubmissionClientInfo
+}
+
+const EMPTY_ATTRIBUTION: SubmissionAttribution = {
+  utmSource: null,
+  utmMedium: null,
+  utmCampaign: null,
+  utmTerm: null,
+  utmContent: null,
+  gclid: null,
+  referrer: null,
+  landingPath: null,
+}
+
+const EMPTY_CLIENT: SubmissionClientInfo = {
+  viewport: null,
+  screenWidth: null,
+  timezone: null,
+  language: null,
+}
+
+export const EMPTY_ANALYTICS: SubmissionAnalytics = {
+  posthogDistinctId: null,
+  posthogSessionId: null,
+  posthogReplayUrl: null,
+}
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined'
+}
+
+function classifyViewport(width: number): ViewportClass {
+  if (width < 768) return 'mobile'
+  if (width < 1024) return 'tablet'
+  return 'desktop'
+}
+
+/** Empty string and whitespace both mean "not present" for our purposes. */
+function nullable(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+/**
+ * Snapshot campaign, referrer, and device context from the current page.
+ *
+ * Honest limitation: UTM params are read from the URL as it stands right now.
+ * Someone who lands on `/?utm_source=x` and then navigates before submitting
+ * arrives with a bare URL, so their attribution is lost. Site-wide first-touch
+ * capture is a separate change.
+ */
+export function collectSubmissionContext(): SubmissionContext {
+  if (!isBrowser()) {
+    return { attribution: EMPTY_ATTRIBUTION, client: EMPTY_CLIENT }
+  }
+
+  const params = new URLSearchParams(window.location.search)
+  const width = window.innerWidth || window.screen?.width || 0
+
+  let timezone: string | null = null
+  try {
+    timezone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? null
+  } catch {
+    timezone = null
+  }
+
+  return {
+    attribution: {
+      utmSource: nullable(params.get('utm_source')),
+      utmMedium: nullable(params.get('utm_medium')),
+      utmCampaign: nullable(params.get('utm_campaign')),
+      utmTerm: nullable(params.get('utm_term')),
+      utmContent: nullable(params.get('utm_content')),
+      gclid: nullable(params.get('gclid')),
+      referrer: nullable(document.referrer),
+      landingPath: window.location.pathname,
+    },
+    client: {
+      viewport: width ? classifyViewport(width) : null,
+      screenWidth: window.screen?.width ?? null,
+      timezone,
+      language: nullable(navigator.language),
+    },
+  }
+}
+
+/**
+ * PostHog ids, read defensively. The client is a no-op singleton when
+ * `NEXT_PUBLIC_POSTHOG_KEY` is unset (as in local dev), and these getters can
+ * throw before `init` has run.
+ */
+export function readSubmissionAnalytics(): SubmissionAnalytics {
+  if (!isBrowser()) return EMPTY_ANALYTICS
+
+  const safely = <T>(read: () => T): T | null => {
+    try {
+      return read() ?? null
+    } catch {
+      return null
+    }
+  }
+
+  return {
+    posthogDistinctId: safely(() => posthog.get_distinct_id()),
+    posthogSessionId: safely(() => posthog.get_session_id()),
+    posthogReplayUrl: safely(() => posthog.get_session_replay_url()),
+  }
+}
+
+/**
+ * A v4 UUID. The portal validates this strictly, so the fallback for non-secure
+ * contexts (where `crypto.randomUUID` is undefined) must still produce a
+ * structurally valid 8-4-4-4-12 v4: four hex chars per group, version nibble 4,
+ * variant nibble 8-b. Not cryptographically random, but well-formed.
+ */
+export function createSubmissionId(): string {
+  if (isBrowser() && typeof crypto?.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  const hex4 = () =>
+    Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .slice(1)
+
+  return [
+    `${hex4()}${hex4()}`,
+    hex4(),
+    `4${hex4().slice(1)}`,
+    `a${hex4().slice(1)}`,
+    `${hex4()}${hex4()}${hex4()}`,
+  ].join('-')
+}

--- a/src/lib/forms/portal.ts
+++ b/src/lib/forms/portal.ts
@@ -1,0 +1,79 @@
+/**
+ * Server-side delivery of form submissions to the portal.
+ *
+ * SERVER ONLY. The intake tokens must never reach the browser, so nothing here
+ * may be imported from a client component. The audit reaches this code through
+ * `app/api/audit-progress/route.ts`; the contact form calls it directly from its
+ * server action.
+ *
+ * Delivery is best-effort by design: a portal outage logs and continues, and the
+ * visitor still sees success. See `docs/prds/005-form-submissions/README.md`.
+ */
+
+/** Paths on the portal, per the integration contract. */
+export const PORTAL_PATHS = {
+  auditResponses: '/api/integrations/audit-responses',
+  contactSubmissions: '/api/integrations/contact-submissions',
+} as const
+
+export interface PortalTarget {
+  url: string
+  token: string
+}
+
+/**
+ * Resolve an endpoint from `PORTAL_API_BASE_URL` plus the caller's token env
+ * var. Returns null when either is unset, which is the signal to log the payload
+ * locally instead of forwarding it.
+ */
+export function resolvePortalTarget(
+  path: string,
+  token: string | undefined
+): PortalTarget | null {
+  const baseUrl = process.env.PORTAL_API_BASE_URL
+
+  if (!baseUrl || !token) return null
+
+  return { url: `${baseUrl.replace(/\/+$/, '')}${path}`, token }
+}
+
+/**
+ * POST a submission to the portal. Never throws, never returns a failure the
+ * caller has to handle: the contract is log-and-continue.
+ *
+ * `context` is folded into any error log so a failure is traceable back to the
+ * submission that produced it without dumping the whole payload.
+ */
+export async function postToPortal(
+  target: PortalTarget,
+  payload: unknown,
+  context: Record<string, unknown>
+): Promise<void> {
+  try {
+    const response = await fetch(target.url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${target.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      console.error('Portal submission rejected', {
+        url: target.url,
+        status: response.status,
+        statusText: response.statusText,
+        body: errorText,
+        ...context,
+      })
+    }
+  } catch (error) {
+    console.error('Portal submission request failed', {
+      url: target.url,
+      error,
+      ...context,
+    })
+  }
+}


### PR DESCRIPTION
## Why

Both marketing forms posted to the portal's `leads-intake` endpoint on final submit only. That meant everyone who abandoned the Opportunity Audit mid-wizard was invisible, the scored result was flattened into a free-text `message` field and could not be queried, and neither form captured UTM attribution or PostHog linkage.

Both forms now land in the portal's `form_submissions` table, surfaced at **Sales → Submissions**. Leads are promoted from there by hand, so the `leads-intake` POST is removed from both actions.

Implements the portal-side integration contract. Full write-up, including limitations: `docs/prds/005-form-submissions/README.md`.

## What changed

**Audit is now captured as it progresses.** It gains a session identity persisted to `localStorage`, which gives it a stable idempotency key, lets a refresh resume where the visitor left off, and keeps every repeat push on one portal row. Pushes go out at each section boundary, when results are scored, on lead capture, and via `sendBeacon` on tab close.

**Contact form** now posts to `contact-submissions` with the same analytics / attribution / client envelope, shared via `src/lib/forms/context.ts`.

**Why the audit proxies and contact does not.** `sendBeacon` cannot set an `Authorization` header, and putting an intake token in the client bundle would publish a portal secret. So the audit beacons to a same-origin route that adds the token server-side:

```
browser ──sendBeacon──▶ marketing /api/audit-progress ──fetch + Bearer──▶ portal
```

The contact form is already a server action and posts directly; its client half only gathers the browser-side context. Both set `client.userAgent` from the request header rather than `navigator.userAgent`.

**BotID protection narrowed** to `/contact` and `/audit`, the two routes whose actions actually call `checkBotId()`. The previous blanket `POST /**` also challenged every audit progress push, which added latency and errored outright in local development.

Delivery is best-effort throughout: a portal outage logs and continues, and the visitor still sees success. The Resend emails and audience opt-in are untouched.

## Sender obligations

The contract names three things the portal cannot do for us:

| Obligation | How it is met |
| --- | --- |
| Stable `sessionId` for the whole session | Minted once in `createAuditSession()`, persisted under `pts_audit_session_v1` |
| Monotonic `updatedAt` | Stamped in `commit()` at the moment of change, immediately before the push |
| `responses` is always the full question set | `describeAnswers()` maps all of `QUESTIONS`, emitting `value: null` for unanswered |

## Deploy notes

⚠️ **Order matters.** The portal endpoints must be live before this merges, or in-flight submissions are dropped.

Set in Vercel (all environments):

- `PORTAL_API_BASE_URL`
- `AUDIT_INTAKE_TOKEN`
- `CONTACT_INTAKE_TOKEN`

Remove after cutover: `PORTAL_LEADS_ENDPOINT`, `PORTAL_LEADS_TOKEN`. No code reads them.

Left unset locally, both paths log the payload to the server console instead of forwarding, so the flow is verifiable with no portal running.

## Verification

- `type-check`, `lint`, and `build` all pass
- Walked the audit end to end against a local dev portal: rows arrive and upsert correctly
- Fixed a bug in the `crypto.randomUUID` fallback for non-secure contexts, which emitted 5 hex chars per group instead of 4 and would have produced ids the portal rejects with a 400. Verified against a v4 regex over 20k samples

## Out of scope, worth knowing

- **Privacy policy.** We now store questionnaire responses and device data server-side for visitors who never identify themselves. `app/privacy/page.tsx` does not describe this.
- **UTM attribution is last-touch at collection time.** Someone who lands on `/?utm_source=x` then navigates before converting loses it. Site-wide first-touch capture is a separate change.
- Three other `next/image` `fill` usages still lack `sizes` (`team-section.tsx`, `app/team/page.tsx`, `clients-section.tsx`). The audit landing one is fixed here since it surfaced during testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
