### PR TITLE
Fix silent email failures and crash-proof audit completion

### DIFF
--- a/app/actions/send-audit.ts
+++ b/app/actions/send-audit.ts
@@ -13,10 +13,25 @@ import {
   renderAuditTeamEmail,
 } from '@/src/lib/emails/audit-emails'
 
+/**
+ * Why a submission failed. Returned to the client so it can report the cause to
+ * PostHog: without this every failure looks identical to an ordinary drop-off.
+ */
+export type AuditFailureReason =
+  | 'validation'
+  | 'botid_blocked'
+  | 'botid_error'
+  | 'not_configured'
+  /** Resend accepted the request and answered with an error object. */
+  | 'email_rejected'
+  /** The request never reached Resend, or it threw for another reason. */
+  | 'email_threw'
+
 export type AuditActionResult =
   | { success: true }
   | {
       success: false
+      reason: AuditFailureReason
       message?: string
       errors?: Partial<Record<keyof AuditLeadValues, string[]>>
     }
@@ -52,6 +67,7 @@ export async function sendAudit(
   if (!parsed.success) {
     return {
       success: false,
+      reason: 'validation',
       errors: parsed.error.flatten().fieldErrors,
     } as const
   }
@@ -68,6 +84,7 @@ export async function sendAudit(
 
       return {
         success: false,
+        reason: 'botid_blocked',
         message:
           "We couldn't verify your request. Please refresh and try again.",
       } as const
@@ -77,6 +94,7 @@ export async function sendAudit(
 
     return {
       success: false,
+      reason: 'botid_error',
       message:
         'Unable to verify your request at this time. Please try again later.',
     } as const
@@ -88,6 +106,7 @@ export async function sendAudit(
   if (!apiKey) {
     return {
       success: false,
+      reason: 'not_configured',
       message: 'Email service is not configured. Please try again later.',
     } as const
   }
@@ -140,10 +159,16 @@ export async function sendAudit(
     'The Place To Stand Team',
   ]
 
-  // Send emails first — this is the core deliverable. If it fails, surface the
+  // Send emails first: this is the core deliverable. If it fails, surface the
   // error so the user can retry; everything below is best-effort enrichment.
+  //
+  // Resend does NOT throw on API errors. It resolves with `{ data: null, error }`
+  // for anything non-2xx (rate limit, suppressed recipient, domain problem), and
+  // only rejects on a network-level failure. An unchecked `await` here reports
+  // success while sending nothing, which is exactly the bug this replaced. Check
+  // `.error` on every send.
   try {
-    await resend.emails.send({
+    const teamEmail = await resend.emails.send({
       from: 'Place To Stand <noreply@notifications.placetostandagency.com>',
       to: ['hello@placetostandagency.com'],
       replyTo: email,
@@ -158,7 +183,16 @@ export async function sendAudit(
       }),
     })
 
-    await resend.emails.send({
+    if (teamEmail.error) {
+      console.error('Resend rejected the team notification', teamEmail.error)
+      return {
+        success: false,
+        reason: 'email_rejected',
+        message: 'Failed to send your audit. Please try again in a moment.',
+      } as const
+    }
+
+    const clientEmail = await resend.emails.send({
       from: 'Place To Stand <noreply@notifications.placetostandagency.com>',
       to: [email],
       replyTo: 'hello@placetostandagency.com',
@@ -166,10 +200,23 @@ export async function sendAudit(
       text: clientEmailLines.join('\n'),
       html: renderAuditClientEmail({ greetingName, result }),
     })
+
+    // The team mail already landed, so a retry sends them a duplicate. A
+    // duplicate lead notification is strictly better than the visitor believing
+    // a result is on its way when none is.
+    if (clientEmail.error) {
+      console.error('Resend rejected the client email', clientEmail.error)
+      return {
+        success: false,
+        reason: 'email_rejected',
+        message: 'Failed to send your audit. Please try again in a moment.',
+      } as const
+    }
   } catch (error) {
     console.error('Email sending failed', error)
     return {
       success: false,
+      reason: 'email_threw',
       message: 'Failed to send confirmation email. Please try again later.',
     } as const
   }

--- a/app/actions/send-contact.ts
+++ b/app/actions/send-contact.ts
@@ -161,12 +161,16 @@ export async function sendContact(
     'The Place To Stand Team'
   )
 
-  // Send emails first — this is the core deliverable. If it fails, surface the
+  // Send emails first: this is the core deliverable. If it fails, surface the
   // error so the user can retry; everything below is best-effort enrichment.
+  //
+  // Resend does NOT throw on API errors. It resolves with `{ data: null, error }`
+  // for anything non-2xx and only rejects on a network-level failure, so an
+  // unchecked `await` here would report success while sending nothing.
   try {
     const emailLines = [...detailLines]
 
-    await resend.emails.send({
+    const teamEmail = await resend.emails.send({
       from: 'Place To Stand <noreply@notifications.placetostandagency.com>',
       to: ['hello@placetostandagency.com'],
       replyTo: email,
@@ -174,13 +178,29 @@ export async function sendContact(
       text: emailLines.join('\n'),
     })
 
-    await resend.emails.send({
+    if (teamEmail.error) {
+      console.error('Resend rejected the team notification', teamEmail.error)
+      return {
+        success: false,
+        message: 'Failed to send your message. Please try again in a moment.',
+      } as const
+    }
+
+    const clientEmail = await resend.emails.send({
       from: 'Place To Stand <noreply@notifications.placetostandagency.com>',
       to: [email],
       replyTo: 'hello@placetostandagency.com',
       subject: 'Thanks for contacting Place To Stand',
       text: clientEmailLines.join('\n'),
     })
+
+    if (clientEmail.error) {
+      console.error('Resend rejected the client email', clientEmail.error)
+      return {
+        success: false,
+        message: 'Failed to send your message. Please try again in a moment.',
+      } as const
+    }
   } catch (error) {
     console.error('Email sending failed', error)
     return {

--- a/app/audit/error.tsx
+++ b/app/audit/error.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePostHog } from 'posthog-js/react'
+import { RotateCcw } from 'lucide-react'
+import { BlueprintCorners } from '@/src/components/layout/dot-grid-background'
+import { TrackedLink } from '@/src/components/tracked-link'
+import { Button } from '@/src/components/ui/button'
+import { getAuditSessionSnapshot } from '@/src/lib/audit/session'
+
+/**
+ * Recovery screen for a client-side crash anywhere in the audit page.
+ *
+ * A finished audit that dies at the results swap is the worst failure on the
+ * site: a paid click that produced answers, a score, and no lead. Before this
+ * existed the crash fell through to Next's blank "Application error" page and
+ * the visitor lost everything.
+ *
+ * Because the result is now rebuilt from stored answers (see
+ * `isResultRecoverable`), retrying is usually enough to land the visitor back on
+ * their own results with the email form intact. So the first retry happens
+ * automatically and silently: on the happy path they see a flash, not an error.
+ */
+
+// Module scope on purpose: survives the boundary remounting, resets on a real
+// page load. One silent retry, then we stop and let the visitor choose.
+let autoRetried = false
+
+export default function AuditError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const posthog = usePostHog()
+
+  useEffect(() => {
+    const session = getAuditSessionSnapshot()
+
+    posthog?.capture('audit_render_failed', {
+      error_name: error.name,
+      error_message: error.message,
+      digest: error.digest ?? null,
+      session_id: session?.sessionId ?? null,
+      session_status: session?.status ?? null,
+      answers_count: session ? Object.keys(session.answers).length : 0,
+      // The property that confirms or refutes the translation diagnosis in
+      // production, which is the whole reason this event is worth capturing.
+      page_translated: isPageTranslated(),
+      auto_retried: autoRetried,
+    })
+
+    if (!autoRetried) {
+      autoRetried = true
+      reset()
+    }
+  }, [error, posthog, reset])
+
+  return (
+    <main className='flex-1 pt-grid-4 pb-32'>
+      <div className='mx-auto w-full max-w-content px-6 lg:px-12'>
+        <div className='relative max-w-2xl border border-border bg-bg-panel p-6 sm:p-8'>
+          <BlueprintCorners size={16} />
+          <span className='bp-label font-mono'>Audit</span>
+          <h1 className='mt-4 font-headline text-2xl font-semibold tracking-tight text-text uppercase sm:text-3xl'>
+            We hit a snag
+          </h1>
+          <p className='mt-4 text-sm text-text-muted'>
+            Your answers are saved. Nothing you filled in was lost.
+          </p>
+          <p className='mt-2 text-sm text-text-muted'>
+            Try again and we will take you straight to your results.
+          </p>
+
+          <div className='mt-6 flex flex-wrap items-center gap-4'>
+            <Button type='button' onClick={reset}>
+              <RotateCcw className='mr-2 h-4 w-4' />
+              Show my results
+            </Button>
+            {/* The one conversion path that does not depend on the crashed
+                tree re-rendering successfully. */}
+            <TrackedLink
+              href='/contact'
+              location='audit-error-fallback'
+              className='text-sm text-accent underline-offset-4 hover:underline'
+            >
+              Book a call instead
+            </TrackedLink>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+/**
+ * Best-effort signal that a translator has rewritten the DOM under React. Three
+ * independent checks because it is not certain which of them Chrome's built-in
+ * translation sets on Android.
+ */
+function isPageTranslated(): boolean {
+  if (typeof document === 'undefined') return false
+
+  const html = document.documentElement
+  return (
+    html.classList.contains('translated-ltr') ||
+    html.classList.contains('translated-rtl') ||
+    (html.lang !== '' && !html.lang.toLowerCase().startsWith('en')) ||
+    document.getElementsByTagName('font').length > 0
+  )
+}

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,4 +1,12 @@
 import { initBotId } from 'botid/client/core'
+import { installTranslationSafeDom } from '@/src/lib/translation-safe-dom'
+
+/**
+ * Runs before the app hydrates, so React never gets the chance to hit a
+ * translator-rewritten node with an unguarded `removeChild`. See the module for
+ * why this is needed and what it costs.
+ */
+installTranslationSafeDom()
 
 /**
  * Protect only the routes whose server actions actually call `checkBotId()`.

--- a/src/components/audit/audit-app.tsx
+++ b/src/components/audit/audit-app.tsx
@@ -3,6 +3,7 @@
 import { AuditLandingContent } from '@/src/components/audit/audit-landing'
 import { AuditWizard } from '@/src/components/audit/audit-wizard'
 import { ResultsView } from '@/src/components/audit/results-view'
+import { BlueprintCorners } from '@/src/components/layout/dot-grid-background'
 import { useAudit } from '@/src/hooks/use-audit'
 
 /** Top-level state machine for the audit: intro to wizard to results. */
@@ -22,7 +23,24 @@ export function AuditApp() {
     reset,
   } = useAudit()
 
-  if (stage === 'results' && result) {
+  if (stage === 'results') {
+    // The result is rebuilt from stored answers on mount, so it can be briefly
+    // absent. This must not fall through to the landing page: doing so is what
+    // made a recoverable session look like lost work.
+    if (!result) {
+      return (
+        <div className='w-full py-grid-2'>
+          <div className='relative border border-border bg-bg-panel p-6 sm:p-8'>
+            <BlueprintCorners size={12} colorClassName='border-border-light' />
+            <span className='bp-label font-mono'>Audit Results</span>
+            <p className='mt-4 text-sm text-text-muted'>
+              Rebuilding your results...
+            </p>
+          </div>
+        </div>
+      )
+    }
+
     return (
       <ResultsView
         result={result}

--- a/src/components/audit/results-view.tsx
+++ b/src/components/audit/results-view.tsx
@@ -327,10 +327,22 @@ function CaptureForm({
   })
 
   const onSubmit = form.handleSubmit(values => {
+    const lead: AuditLeadPayload = {
+      name: values.name.trim(),
+      email: values.email.trim(),
+      company: values.company?.trim() || null,
+      marketingConsent: values.marketingConsent ?? false,
+    }
+
     startTransition(() => {
-      void sendAudit(values, result, answers, auditSessionId).then(
-        (res: AuditActionResult) => {
+      void sendAudit(values, result, answers, auditSessionId)
+        .then((res: AuditActionResult) => {
           if (!res.success) {
+            posthog?.capture('audit_capture_failed', {
+              reason: res.reason,
+              phase: result.phase.id,
+            })
+
             if (res.errors) {
               Object.entries(res.errors).forEach(([key, messages]) => {
                 const typedMessages = messages as string[] | undefined
@@ -341,6 +353,17 @@ function CaptureForm({
                   })
                 }
               })
+            }
+
+            // The email failed but the details are real and already typed. Push
+            // the lead to the portal anyway so it is recoverable by hand, rather
+            // than losing a finished audit to a Resend outage. Validation and
+            // bot blocks are excluded: those details are not trustworthy.
+            if (
+              res.reason === 'email_rejected' ||
+              res.reason === 'email_threw'
+            ) {
+              onCaptured(lead)
             }
 
             toast({
@@ -354,14 +377,22 @@ function CaptureForm({
           form.reset()
           setIsSuccess(true)
           posthog?.capture('audit_capture_submitted', { phase: result.phase.id })
-          onCaptured({
-            name: values.name.trim(),
-            email: values.email.trim(),
-            company: values.company?.trim() || null,
-            marketingConsent: values.marketingConsent ?? false,
+          onCaptured(lead)
+        })
+        .catch((error: unknown) => {
+          // The action itself rejected (deploy skew, cold-start failure). Without
+          // this the button stays stuck on "Sending..." with no explanation.
+          posthog?.capture('audit_capture_failed', {
+            reason: 'action_threw',
+            phase: result.phase.id,
           })
-        }
-      )
+          posthog?.captureException(error)
+          toast({
+            variant: 'destructive',
+            title: 'Something went wrong',
+            description: 'Please try again.',
+          })
+        })
     })
   })
 

--- a/src/components/posthog-provider.tsx
+++ b/src/components/posthog-provider.tsx
@@ -40,6 +40,10 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         capture_pageleave: true,
         autocapture: true,
         capture_dead_clicks: true,
+        // Pinned here rather than left to the PostHog project setting: error
+        // tracking is load-bearing for the audit funnel, and a UI toggle would
+        // otherwise switch it off with nothing in the repo to explain it.
+        capture_exceptions: true,
         before_send: dropInjectedScriptExceptions,
       })
     }

--- a/src/components/sections/contact-section.tsx
+++ b/src/components/sections/contact-section.tsx
@@ -60,9 +60,11 @@ export function ContactSection() {
     }
 
     startTransition(() => {
-      void sendContact(values, submissionContext).then(
-        (result: ContactActionResult) => {
+      void sendContact(values, submissionContext)
+        .then((result: ContactActionResult) => {
           if (!result.success) {
+            posthog?.capture('contact_form_failed')
+
             if (result.errors) {
               Object.entries(result.errors).forEach(([key, messages]) => {
                 const typedMessages = messages as string[] | undefined
@@ -86,8 +88,18 @@ export function ContactSection() {
           form.reset()
           setIsSuccess(true)
           posthog?.capture('contact_form_submitted')
-        }
-      )
+        })
+        .catch((error: unknown) => {
+          // The action itself rejected. Without this the button stays stuck on
+          // its pending state with no explanation.
+          posthog?.capture('contact_form_failed', { reason: 'action_threw' })
+          posthog?.captureException(error)
+          toast({
+            variant: 'destructive',
+            title: 'Something went wrong',
+            description: 'Please try again.',
+          })
+        })
     })
   })
 

--- a/src/hooks/use-audit.ts
+++ b/src/hooks/use-audit.ts
@@ -19,12 +19,14 @@ import {
   createAuditSession,
   getAuditSessionServerSnapshot,
   getAuditSessionSnapshot,
+  isResultRecoverable,
   isResumable,
   setAuditSession,
   subscribeToAuditSession,
   type AuditSession,
   type AuditStatus,
 } from '@/src/lib/audit/session'
+import { toast } from '@/src/components/ui/use-toast'
 import { sendAuditProgress } from '@/src/lib/audit/track-progress'
 import type {
   AnswerValue,
@@ -78,8 +80,16 @@ export function useAudit(): UseAudit {
   const [result, setResult] = useState<AuditResult | null>(null)
   const [isScoring, setIsScoring] = useState(false)
 
+  // A completed session outranks a resumable one: someone who finished and then
+  // lost the page (a crash, a closed tab) should land back on their results,
+  // not be asked to take the audit again.
   const stage: AuditStage =
-    chosenStage ?? (isResumable(session) ? 'wizard' : 'intro')
+    chosenStage ??
+    (isResultRecoverable(session)
+      ? 'results'
+      : isResumable(session)
+        ? 'wizard'
+        : 'intro')
 
   const completedAtRef = useRef<string | null>(null)
   /** True when answers changed since the last push, so pagehide can skip. */
@@ -141,6 +151,40 @@ export function useAudit(): UseAudit {
     })
   }, [posthog])
 
+  // Rebuild the result for a session that was already scored but whose result is
+  // no longer in memory. `runAudit` is pure over the stored answers, so this is
+  // exact, not an approximation. Deliberately has no cleanup flag: under
+  // `reactStrictMode` the effect runs twice, and a `cancelled` flag combined
+  // with the ref guard would permanently swallow the only in-flight restore.
+  const restoreAttemptedRef = useRef(false)
+  useEffect(() => {
+    if (restoreAttemptedRef.current || result) return
+
+    const stored = getAuditSessionSnapshot()
+    if (!isResultRecoverable(stored) || !stored) return
+
+    restoreAttemptedRef.current = true
+    void runAudit(stored.answers)
+      .then(scored => {
+        setResult(scored)
+        completedAtRef.current = stored.updatedAt
+        posthog?.capture('audit_results_restored', {
+          phase: scored.phase.id,
+          answers_count: Object.keys(stored.answers).length,
+        })
+      })
+      .catch(() => {
+        // Scored once but unscoreable now. Send them somewhere usable rather
+        // than leaving the results stage empty forever.
+        setChosenStage('intro')
+        toast({
+          variant: 'destructive',
+          title: 'We could not rebuild your results',
+          description: 'Your answers are saved. Start the audit to see them.',
+        })
+      })
+  }, [result, posthog])
+
   const setAnswer = useCallback(
     (questionId: string, value: AnswerValue) => {
       commit(prev => ({
@@ -157,6 +201,28 @@ export function useAudit(): UseAudit {
   )
 
   const start = useCallback(() => {
+    const stored = getAuditSessionSnapshot()
+
+    // Never mint a second session on top of answers we could still use. This is
+    // reachable when a scored session failed to rebuild: without the reopen the
+    // visitor's answers would be overwritten and the portal would gain a
+    // duplicate row for the same attempt. `reset()` still nulls the session, so
+    // a deliberate "Start over" continues to yield a genuinely fresh id.
+    if (stored && Object.keys(stored.answers).length > 0) {
+      const reopened = commit(prev => ({ ...prev, status: 'in_progress' }))
+
+      setResult(null)
+      completedAtRef.current = null
+      dirtyRef.current = false
+      setChosenStage('wizard')
+
+      posthog?.capture('audit_started', { reopened: true })
+      if (reopened) {
+        push({ session: reopened, status: 'in_progress', trigger: 'started' })
+      }
+      return
+    }
+
     const fresh = createAuditSession()
     setAuditSession(fresh)
 
@@ -168,7 +234,7 @@ export function useAudit(): UseAudit {
 
     posthog?.capture('audit_started')
     push({ session: fresh, status: 'in_progress', trigger: 'started' })
-  }, [posthog, push])
+  }, [posthog, push, commit])
 
   const completeStep = useCallback(
     (stepIndex: number) => {

--- a/src/lib/audit/session.ts
+++ b/src/lib/audit/session.ts
@@ -23,8 +23,9 @@ export const AUDIT_SESSION_KEY = 'pts_audit_session_v1'
 export const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000
 
 /**
- * How far the attempt got. Also the resume gate: only `in_progress` sessions are
- * restored, so finishing the audit and coming back later starts a fresh one.
+ * How far the attempt got. Also the resume gate, in two parts: `in_progress`
+ * reopens the wizard (`isResumable`), `completed` rebuilds the results
+ * (`isResultRecoverable`). A `captured` attempt is finished and starts fresh.
  * The portal only ever advances a row along this order, never backwards.
  */
 export type AuditStatus = 'in_progress' | 'completed' | 'captured' | 'abandoned'
@@ -174,6 +175,28 @@ export function isResumable(session: AuditSession | null): boolean {
   return (
     session !== null &&
     session.status === 'in_progress' &&
+    Object.keys(session.answers).length > 0
+  )
+}
+
+/**
+ * Whether a stored session carries enough to rebuild the result the visitor
+ * already earned. `runAudit` is pure over `answers`, so a scored result is
+ * always re-derivable and never needs storing: persisting it would freeze the
+ * phase and service copy into localStorage for the session's whole lifetime.
+ *
+ * This is what makes a crash at the wizard-to-results swap survivable. Without
+ * it, a `completed` session fails `isResumable` and the visitor lands back on
+ * the intro with their answers stranded.
+ *
+ * `completed` only, never `captured`: that visitor already has the result in
+ * their inbox, and reopening them onto a blank capture form invites a duplicate
+ * submission and a second pair of emails.
+ */
+export function isResultRecoverable(session: AuditSession | null): boolean {
+  return (
+    session !== null &&
+    session.status === 'completed' &&
     Object.keys(session.answers).length > 0
   )
 }

--- a/src/lib/translation-safe-dom.ts
+++ b/src/lib/translation-safe-dom.ts
@@ -1,0 +1,74 @@
+/**
+ * Makes React's DOM teardown survive a page that a translator has rewritten.
+ *
+ * Chrome's built-in translation (and Google Translate generally) rewraps text
+ * nodes in injected `<font>` elements, reparenting nodes React is still
+ * tracking. When React later unmounts that subtree it calls
+ * `parent.removeChild(node)` against the parent it remembers, the browser sees
+ * a different parent, and throws:
+ *
+ *   NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be
+ *   removed is not a child of this node.
+ *
+ * That is uncatchable by anything downstream: it happens in React's commit
+ * phase and takes the whole page with it. It killed a completed audit in
+ * production on 2026-08-02 (Android Chrome, es-US, Mexico, paid click) at the
+ * exact moment the wizard unmounted to show the results.
+ *
+ * The two guards below make both mutations tolerant instead of fatal. React
+ * only calls `removeChild` on the top-most host nodes of a deleted subtree, so
+ * guarding these two methods covers the whole class of failure, anywhere on the
+ * site: the audit's stage swap, the capture form's success swap, the header
+ * nav, toast dismissal.
+ *
+ * Cost, stated plainly: this patches a DOM prototype for every script on the
+ * page, and on a translated page the resulting node order can end up slightly
+ * wrong. A slightly wrong page beats a blank one.
+ *
+ * Deliberately different from the widely copied workaround in
+ * facebook/react#11538, which returns the node without detaching it. That
+ * leaves an orphaned translated copy of the old view visible underneath the new
+ * one. Detaching from the real parent, and appending rather than dropping, is
+ * what keeps the page correct as well as alive.
+ */
+export function installTranslationSafeDom(): void {
+  // No-op during SSR, where there is no DOM to patch.
+  if (typeof Node === 'undefined') return
+
+  const proto = Node.prototype as Node & { __ptsTranslationSafe?: boolean }
+  if (proto.__ptsTranslationSafe) return
+  proto.__ptsTranslationSafe = true
+
+  const nativeRemoveChild = Node.prototype.removeChild
+  Node.prototype.removeChild = function removeChild<T extends Node>(
+    this: Node,
+    child: T
+  ): T {
+    if (child.parentNode !== this) {
+      // Reparented under our feet. Detach it from wherever it actually lives so
+      // it does not linger on screen. This re-enters the patched function once,
+      // where the parent now matches and the native call runs. One level of
+      // recursion, never a loop. A node with no parent at all is already gone,
+      // so returning it unchanged is correct.
+      child.parentNode?.removeChild(child)
+      return child
+    }
+
+    return nativeRemoveChild.call(this, child) as T
+  }
+
+  const nativeInsertBefore = Node.prototype.insertBefore
+  Node.prototype.insertBefore = function insertBefore<T extends Node>(
+    this: Node,
+    node: T,
+    reference: Node | null
+  ): T {
+    if (reference && reference.parentNode !== this) {
+      // The node we were told to insert before has moved. Append instead of
+      // throwing: position may be off, but the content still renders.
+      return this.appendChild(node)
+    }
+
+    return nativeInsertBefore.call(this, node, reference) as T
+  }
+}


### PR DESCRIPTION
## Why

PostHog showed 8 `audit_started`, 4 `audit_completed`, 3 `audit_results_viewed`, 2 `audit_capture_submitted` over 7 days. Chasing that gap turned up two separate problems, one of which analytics could not see at all.

## 1. Resend failures were silent

`resend.emails.send()` does not throw on API errors. It resolves with `{ data: null, error }` for anything non-2xx (`node_modules/resend/dist/index.mjs:1163-1179`) and only rejects on a network-level failure, so the surrounding `try/catch` only ever caught the network case.

Both server actions awaited the sends and never read `.error`. Any rate limit, suppressed recipient, or domain problem returned `{ success: true }`: the visitor saw "Check your inbox", no email reached them or the team, and nothing was logged. The same file already reads `.error` correctly for `resend.contacts.create`, so this was an oversight rather than a convention.

Both sends now check `.error`, and `AuditActionResult` carries an `AuditFailureReason` so the client can report *why* a submission failed rather than just *that* it did.

## 2. The audit crashed at the completion moment

Session `019fc15c-ffac-78ce-bb87-1f56f0df9cb2`, 2026-08-02:

```
07:25:50.799  audit_step_completed
07:25:50.869  audit_completed          (scoring succeeded)
07:25:50.890  $exception  DOMException NotFoundError: removeChild
07:25:50.900  $exception  DOMException NotFoundError: removeChild
              audit_results_viewed     never fired
```

Android Chrome 150, `$browser_language: es-US`, `$geoip_country_code: MX`, arriving on a Google Ads click (`utm_campaign=audit-stage1`, gclid). The session recording ends at the crash. `<html lang='en'>` triggers Chrome auto-translate, which rewraps text nodes in injected `<font>` elements, so when React unmounted the wizard subtree `removeChild` hit a node that was no longer where React left it. One of four completions in the window died this way, on paid traffic.

Two things made it a total loss rather than a glitch: there was no error boundary anywhere in the app, and the scored result lived only in React state while the session status was already `completed`, so `isResumable` returned false and a reload landed on the intro with the answers stranded and about to be overwritten by a fresh `sessionId`.

Three changes:

- **`src/lib/translation-safe-dom.ts`** guards `removeChild` and `insertBefore` against translator-reparented nodes, installed from `instrumentation-client.ts` before hydration. It detaches from the real parent rather than returning the node untouched the way the widely copied React #11538 workaround does, which would leave a ghost of the wizard visible under the results.
- **Result recovery.** `isResultRecoverable` sits alongside `isResumable` rather than widening it, so the wizard resume gate stays `in_progress`. A `completed` session now derives stage `results` and rebuilds the score via `runAudit`, which is pure over the stored answers. `start()` reopens a session that still has answers instead of overwriting it, keeping one portal row per attempt.
- **`app/audit/error.tsx`** retries once silently, which given the above usually lands the visitor back on their own results with the capture form intact, and otherwise shows a recovery panel with a `/contact` link.

## 3. Failure visibility

`audit_capture_failed` with reason codes, the missing `.catch()` on both server-action promises (a rejection previously left the submit button stuck on "Sending..." forever with no toast), and `capture_exceptions` pinned in `posthog.init` rather than left to a PostHog project toggle. When an email fails, the lead is still pushed to the portal so it stays recoverable by hand.

## Verification

- `npm run type-check`, `npm run lint`, `npm run build` all pass.
- DOM guard semantics verified in the browser console: normal removal unaffected, a `<font>`-reparented removal no longer throws and leaves no ghost node, and `insertBefore` with a moved reference appends rather than throwing.

Prettier flags `send-contact.ts` and `results-view.tsx`, but both were already unformatted on `main` (verified against a stash), so they are left alone rather than mixing unrelated reformatting into this diff.

## Follow-ups, not in this PR

- Suppress the unresolved iOS `o.id` TypeError in the PostHog UI rather than filtering it in code. 7 events, 1 person, 90 days, never on `/audit`. `o` is a minified identifier that changes every build, so a regex would be both too broad and useless after the next deploy.
- PostHog sourcemap upload, so the next crash has readable frames instead of `ur` / `i7`.
- An alert on `audit_capture_failed`.
- The `audit-stage1` campaign is buying Spanish-language Mexico traffic that was not intended. Ad targeting, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)