### PR TITLE
Capture attribution at first touch, not at submit

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import type { ReactNode } from 'react'
+import { Suspense, type ReactNode } from 'react'
 import Script from 'next/script'
 import { Space_Grotesk, Bebas_Neue, Source_Sans_3 } from 'next/font/google'
 import './globals.css'
@@ -10,6 +10,7 @@ import { Header } from '@/src/components/layout/header'
 import { Footer } from '@/src/components/layout/footer'
 import { PostHogProvider } from '@/src/components/posthog-provider'
 import { ScrollDepthTracker } from '@/src/components/scroll-depth-tracker'
+import { AttributionCapture } from '@/src/components/attribution-capture'
 
 const spaceGrotesk = Space_Grotesk({
   subsets: ['latin'],
@@ -78,6 +79,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           sourceSans.variable
         )}
       >
+        {/*
+          A sibling of PostHogProvider, not a child: that provider returns its
+          children untouched when NEXT_PUBLIC_POSTHOG_KEY is unset, so nesting
+          this inside it would stop attribution capture running in local dev.
+        */}
+        <Suspense fallback={null}>
+          <AttributionCapture />
+        </Suspense>
         <PostHogProvider>
           <div className='relative flex min-h-screen flex-col overflow-x-hidden'>
             <Header />

--- a/docs/prds/006-first-touch-attribution/README.md
+++ b/docs/prds/006-first-touch-attribution/README.md
@@ -1,0 +1,187 @@
+# 006 — First-touch attribution capture
+
+**Status:** planned, not implemented. Repo: `place-to-stand` (marketing). No portal changes required.
+
+## Why
+
+Every paid conversion is arriving at the portal with null attribution. The Google Ads tagging is
+correct and PostHog receives it in full — we lose it in our own client code between the landing page
+and the form.
+
+Evidence, from PostHog (`execute-sql`, 60-day window), for the one campaign session that produced a
+captured lead (session `019fc15c-ffac-78ce-bb87-1f56f0df9cb2`, 2026-08-02):
+
+```
+07:25:26  $pageview  /?utm_source=google&utm_medium=cpc&utm_campaign=audit-stage1
+                      &utm_content=custom-software&gad_source=1&gad_campaignid=24075829112
+                      &gclid=CjwKCAjw1bvTBhBb…          referrer: https://www.google.com/
+07:25:30  $pageview  /audit                              ← query string gone
+07:25:52  $pageview  /?utm_source=google&…
+```
+
+The matching `form_submissions` row has `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`,
+`utm_content` and `gclid` all null, with `referrer = https://www.google.com/` and
+`landing_path = /audit`.
+
+**Mechanism.** `collectSubmissionContext()` (`src/lib/forms/context.ts:97`) reads
+`window.location.search` at the moment it is called. For the audit that is `createAuditSession()`
+(`src/lib/audit/session.ts:58`), which fires when the visitor starts the wizard on `/audit`; for the
+contact form it is `onSubmit` on `/contact`. Neither page carries the query string, because the ad's
+Final URL points at `/` and the visitor navigates client-side. `document.referrer` survives SPA
+navigation, which is why the referrer field looks healthy and masks the problem.
+
+**Scale.** All 49 campaign sessions in the last 60 days entered on `/`. Not one entered on `/audit` or
+`/contact`. So the current code path captures paid attribution essentially never.
+
+This is the limitation already named in `docs/prds/005-form-submissions/README.md` § Known limitations
+and in the comment at `src/lib/forms/context.ts:87-90`. This PRD closes it.
+
+## Goals
+
+- Attribution captured at first touch and preserved across any number of client-side navigations.
+- Both forms fixed by one change — they already share `collectSubmissionContext()`.
+- `landingPath` means the actual landing page, not the page the form happened to sit on.
+- No change to the wire contract, so the portal needs no deploy.
+
+## Non-goals
+
+- Multi-touch or channel-attribution modelling. First touch wins; that is all.
+- A consent gate (still open from 005).
+- Backfilling historical rows (see § Follow-ups).
+- Changing the Google Ads Final URL. Worth doing independently and takes a minute, but it is a
+  stopgap: it only helps visitors who convert without navigating away, and does nothing for
+  `/contact`. It is not a substitute for this change.
+
+## Design
+
+### Storage and lifetime
+
+`localStorage`, key `pts_attribution_v1`, 30-day TTL.
+
+`sessionStorage` would fix the observed failure (same-tab navigation) and is simpler, but it drops the
+case worth the most: someone clicks the ad, leaves, returns two days later and converts. That is a
+campaign-driven conversion and should be attributed as one. 30 days matches a conventional paid
+lookback window and bounds the staleness. The audit already keeps a 7-day localStorage session, so
+this is a familiar pattern in the codebase, not a new one.
+
+Stored shape:
+
+```ts
+interface StoredAttribution {
+  utmSource: string | null
+  utmMedium: string | null
+  utmCampaign: string | null
+  utmTerm: string | null
+  utmContent: string | null
+  gclid: string | null
+  referrer: string | null      // document.referrer at first touch
+  landingPath: string | null   // pathname at first touch
+  capturedAt: string           // ISO 8601, drives the TTL
+}
+```
+
+### Write rule
+
+On every page load (including client-side route changes):
+
+1. Parse campaign params from the current URL.
+2. **If the URL carries any campaign param** — write, overwriting whatever was stored. A fresh ad
+   click is newer and better information than a month-old first touch.
+3. **Otherwise, if nothing is stored (or the stored record is past its TTL)** — write a record with
+   null campaign fields but a real `referrer` and `landingPath`, so organic first touch is still
+   captured.
+4. **Otherwise** — leave it alone. This is the case that fixes the bug: navigating `/` → `/audit` must
+   not clobber the campaign data captured on `/`.
+
+"Any campaign param" means any of the five `utm_*` or `gclid`. Empty and whitespace-only values do not
+count — reuse the existing `nullable()` helper.
+
+### Read precedence
+
+`collectSubmissionContext()` resolves each field as: **current URL → stored → null.**
+
+The current URL still wins when it has params, so a direct-landing conversion behaves exactly as it
+does today and the change is a pure superset of current behaviour. `landingPath` comes from the stored
+record first, falling back to `window.location.pathname` when nothing is stored — that fallback keeps
+the field populated for a visitor whose storage is unavailable.
+
+Resolve the campaign block as a unit, not field by field: if the current URL has any campaign param,
+take all six from the URL; otherwise take all six from storage. Mixing a `utm_source` from the URL with
+a `gclid` from a different, older visit would fabricate a campaign that never existed.
+
+### Where capture runs
+
+A new client component `<AttributionCapture />` mounted in `app/layout.tsx`, wrapped in its own
+`<Suspense>` boundary.
+
+Three constraints drive this:
+
+- It reads `useSearchParams()`, which without a Suspense boundary opts the entire route into
+  client-side rendering.
+- It must run on the first paint of the first page, before any navigation.
+- **It must not live inside `PostHogProvider`.** That component early-returns `<>{children}</>` when
+  `NEXT_PUBLIC_POSTHOG_KEY` is unset (`src/components/posthog-provider.tsx:48-50`), which is the case
+  in local dev — capture would silently not run there, and the first anyone would notice is null
+  attribution in production again. Mount it as a sibling.
+
+`PostHogPageView` in the same file is the closest existing model for the hook usage.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `src/lib/forms/attribution-store.ts` | **New.** `readStoredAttribution()`, `captureAttribution()`, the TTL constant, the storage key. All storage access wrapped in try/catch, matching `src/lib/audit/session.ts:106-124` — Safari private mode throws on `setItem` and must never break a page render. |
+| `src/components/attribution-capture.tsx` | **New.** Client component. `useSearchParams()` + `usePathname()` in a `useEffect` calling `captureAttribution()`. Renders `null`. |
+| `app/layout.tsx` | Mount `<Suspense fallback={null}><AttributionCapture /></Suspense>` inside `<body>`, as a sibling of `PostHogProvider`, not a child. |
+| `src/lib/forms/context.ts` | `collectSubmissionContext()` merges current URL over stored per § Read precedence. Signature unchanged. Replace the stale limitation comment at lines 84-91 with a description of the precedence rule. |
+
+`src/components/sections/contact-section.tsx` and `src/lib/audit/session.ts` are untouched — they call
+`collectSubmissionContext()` and inherit the fix.
+
+## Edge cases
+
+- **In-flight audit sessions.** `createAuditSession()` freezes its context at mint time and
+  `localStorage` holds it for 7 days, so audits started before the deploy keep their null attribution
+  until they expire. Do **not** bump `AUDIT_SESSION_KEY` to force them out — that would wipe genuine
+  in-progress audits to fix at most a handful of rows. It self-heals in a week.
+- **Storage refused.** Every read and write is best-effort. With storage unavailable the behaviour
+  degrades to exactly what ships today, which is the correct floor.
+- **`landingPath` semantics change.** Rows written before this change store the *submission* path;
+  rows after store the *landing* path. Same column, two meanings, split at the deploy date. Note it
+  wherever the field is analysed. The new meaning is the one the name always implied.
+- **The stored `referrer` will differ from today's value** for anyone who lands, leaves the site, and
+  returns before converting. First-touch referrer is the intended semantics.
+
+## Testing
+
+Manual, on a preview deploy. Steps 1 and 2 are the regression that matters.
+
+1. Load `/?utm_source=google&utm_medium=cpc&utm_campaign=audit-stage1&gclid=test123`, navigate to
+   `/audit` via the nav (not a reload), complete the audit and capture. Portal row must show all four
+   values plus `landing_path = /`.
+2. Same, but navigate to `/contact` and submit. Same expectation.
+3. Land directly on `/audit?utm_source=direct`, convert without navigating. `utm_source = direct` —
+   confirms the current-URL path still wins.
+4. Complete step 1, then in a fresh tab load `/` bare and convert. Attribution still present from
+   storage.
+5. With a stored record, load `/?utm_source=second&utm_campaign=other` and convert. New campaign
+   overwrites; no mixing with the first.
+6. Clear storage, load `/` bare, convert. Campaign fields null, `referrer` and `landing_path`
+   populated — no crash, no regression versus today.
+7. Safari private browsing, step 1. Audit completes and submits; attribution may be absent.
+8. Confirm no hydration warnings in the console and that `/` is still server-rendered — a missing
+   Suspense boundary around `useSearchParams` shows up here.
+
+## Follow-ups (separate work, not blocking)
+
+- **Point the Google Ads Final URL at `/audit`.** Independent of this change, no code, starts
+  recovering data immediately. See the campaign at `gad_campaignid=24075829112`.
+- **Backfill historical rows.** Submissions store `posthog_session_id` and `posthog_distinct_id`, and
+  PostHog holds the UTMs and gclid keyed by session id. A one-off script can join on that and populate
+  the null columns. Recoverable, small volume.
+- **Additional click ids.** `wbraid` / `gbraid` replace `gclid` on iOS Google Ads traffic, so those
+  conversions carry no `gclid` at all; `msclkid` and `fbclid` matter if spend ever moves off Google.
+  Capturing them needs a column and envelope change in the portal (`packages/db/src/schema.ts`,
+  `apps/internal/lib/form-submissions/envelope.ts`) — cross-repo, hence separate.
+- **`firstTouchAt` on the wire.** The stored record carries it; the payload has nowhere to put it.
+  Adding a column would let analysis separate same-session conversions from delayed ones.

--- a/src/components/attribution-capture.tsx
+++ b/src/components/attribution-capture.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { usePathname, useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
+import { captureAttribution } from '@/src/lib/forms/attribution-store'
+
+/**
+ * Records first-touch attribution on every page load and client-side route
+ * change. Renders nothing.
+ *
+ * Mounted in `app/layout.tsx` as a sibling of `PostHogProvider`, deliberately
+ * not a child: that provider early-returns its children untouched when
+ * `NEXT_PUBLIC_POSTHOG_KEY` is unset, which is the case in local dev, so
+ * anything nested inside it silently never runs there.
+ *
+ * `useSearchParams` needs a `<Suspense>` boundary around this component or the
+ * whole route opts out of static rendering. `PostHogPageView` does the same.
+ */
+export function AttributionCapture() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    captureAttribution(searchParams.toString(), pathname)
+  }, [pathname, searchParams])
+
+  return null
+}

--- a/src/lib/forms/attribution-store.ts
+++ b/src/lib/forms/attribution-store.ts
@@ -1,0 +1,169 @@
+/**
+ * First-touch attribution, captured on landing and preserved across navigation.
+ *
+ * The problem this exists to solve: our ads point at `/`, but conversions happen
+ * on `/audit` and `/contact`. Reading `window.location.search` at submit time
+ * therefore sees a bare URL and records nothing, so paid attribution was lost on
+ * essentially every campaign visit. See
+ * `docs/prds/006-first-touch-attribution/README.md`.
+ *
+ * `<AttributionCapture />` calls `captureAttribution()` on every page load and
+ * client-side route change; `collectSubmissionContext()` reads the result back.
+ *
+ * Client-only, and every storage call is defensive: Safari private mode throws
+ * on `setItem`, and a storage failure must never break a page render.
+ */
+
+export const ATTRIBUTION_KEY = 'pts_attribution_v1'
+
+/**
+ * A conventional paid lookback window. Long enough to attribute the visitor who
+ * clicks an ad, leaves, and converts days later; short enough to bound how stale
+ * a first touch can get.
+ */
+export const ATTRIBUTION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+/** The six campaign fields, always resolved together. */
+export interface CampaignParams {
+  utmSource: string | null
+  utmMedium: string | null
+  utmCampaign: string | null
+  utmTerm: string | null
+  utmContent: string | null
+  gclid: string | null
+}
+
+export interface StoredAttribution extends CampaignParams {
+  /** `document.referrer` at first touch. */
+  referrer: string | null
+  /** Pathname at first touch, i.e. the page the visitor actually landed on. */
+  landingPath: string | null
+  /** ISO 8601. Drives the TTL. */
+  capturedAt: string
+}
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined'
+}
+
+/** Empty string and whitespace both mean "not present" for our purposes. */
+export function nullable(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+/** Read a field off untrusted parsed JSON without letting non-strings through. */
+function storedField(
+  record: Record<string, unknown>,
+  key: string
+): string | null {
+  const value = record[key]
+  return typeof value === 'string' ? nullable(value) : null
+}
+
+export function parseCampaignParams(search: string): CampaignParams {
+  const params = new URLSearchParams(search)
+
+  return {
+    utmSource: nullable(params.get('utm_source')),
+    utmMedium: nullable(params.get('utm_medium')),
+    utmCampaign: nullable(params.get('utm_campaign')),
+    utmTerm: nullable(params.get('utm_term')),
+    utmContent: nullable(params.get('utm_content')),
+    gclid: nullable(params.get('gclid')),
+  }
+}
+
+/** Whether a URL says anything at all about where the visitor came from. */
+export function hasCampaign(campaign: CampaignParams): boolean {
+  return Object.values(campaign).some(value => value !== null)
+}
+
+/** The stored first touch, or null when absent, unreadable, or past the TTL. */
+export function readStoredAttribution(): StoredAttribution | null {
+  if (!isBrowser()) return null
+
+  try {
+    const raw = window.localStorage.getItem(ATTRIBUTION_KEY)
+    if (!raw) return null
+
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return null
+
+    const record = parsed as Record<string, unknown>
+    const capturedAt = record.capturedAt
+    if (typeof capturedAt !== 'string') return null
+
+    const age = Date.now() - new Date(capturedAt).getTime()
+    if (!Number.isFinite(age) || age > ATTRIBUTION_TTL_MS) {
+      removeStoredAttribution()
+      return null
+    }
+
+    return {
+      utmSource: storedField(record, 'utmSource'),
+      utmMedium: storedField(record, 'utmMedium'),
+      utmCampaign: storedField(record, 'utmCampaign'),
+      utmTerm: storedField(record, 'utmTerm'),
+      utmContent: storedField(record, 'utmContent'),
+      gclid: storedField(record, 'gclid'),
+      referrer: storedField(record, 'referrer'),
+      landingPath: storedField(record, 'landingPath'),
+      capturedAt,
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeStoredAttribution(attribution: StoredAttribution): void {
+  if (!isBrowser()) return
+
+  try {
+    window.localStorage.setItem(ATTRIBUTION_KEY, JSON.stringify(attribution))
+  } catch {
+    // Private mode, quota exceeded, or storage disabled. Attribution falls back
+    // to whatever the submitting page's own URL carries, which is exactly the
+    // behaviour that shipped before this module existed.
+  }
+}
+
+function removeStoredAttribution(): void {
+  if (!isBrowser()) return
+
+  try {
+    window.localStorage.removeItem(ATTRIBUTION_KEY)
+  } catch {
+    // Nothing useful to do here.
+  }
+}
+
+/**
+ * Record the first touch for this visitor, if this page load is one.
+ *
+ * Three cases, in order:
+ *
+ * 1. The URL carries a campaign param — write, overwriting whatever was stored.
+ *    A fresh ad click is newer and better information than a month-old touch.
+ * 2. Nothing stored, or the stored record has expired — write a record with null
+ *    campaign fields, so an organic first touch still gets a referrer and a
+ *    landing path.
+ * 3. Otherwise leave it alone. This is the case that fixes the bug: navigating
+ *    `/` → `/audit` must not clobber the campaign data captured on `/`.
+ */
+export function captureAttribution(search: string, pathname: string): void {
+  if (!isBrowser()) return
+
+  const campaign = parseCampaignParams(search)
+
+  // `readStoredAttribution` clears an expired record and reports null, so case 2
+  // falls through to the write below.
+  if (!hasCampaign(campaign) && readStoredAttribution() !== null) return
+
+  writeStoredAttribution({
+    ...campaign,
+    referrer: nullable(document.referrer),
+    landingPath: nullable(pathname) ?? nullable(window.location.pathname),
+    capturedAt: new Date().toISOString(),
+  })
+}

--- a/src/lib/forms/context.ts
+++ b/src/lib/forms/context.ts
@@ -8,6 +8,13 @@
  * Client-only: reads `window`, `document`, and the PostHog browser client.
  */
 import posthog from 'posthog-js'
+import {
+  hasCampaign,
+  nullable,
+  parseCampaignParams,
+  readStoredAttribution,
+  type CampaignParams,
+} from './attribution-store'
 
 export type ViewportClass = 'mobile' | 'tablet' | 'desktop'
 
@@ -75,26 +82,30 @@ function classifyViewport(width: number): ViewportClass {
   return 'desktop'
 }
 
-/** Empty string and whitespace both mean "not present" for our purposes. */
-function nullable(value: string | null | undefined): string | null {
-  const trimmed = value?.trim()
-  return trimmed ? trimmed : null
-}
-
 /**
  * Snapshot campaign, referrer, and device context from the current page.
  *
- * Honest limitation: UTM params are read from the URL as it stands right now.
- * Someone who lands on `/?utm_source=x` and then navigates before submitting
- * arrives with a bare URL, so their attribution is lost. Site-wide first-touch
- * capture is a separate change.
+ * Attribution resolves as **current URL → stored first touch → null**, the
+ * stored record coming from `<AttributionCapture />`. That fallback is the whole
+ * point: the ads land on `/` but conversions happen on `/audit` and `/contact`,
+ * so by the time this runs the URL is usually bare.
+ *
+ * The campaign block resolves as a unit rather than field by field. Pairing a
+ * `utm_source` read off this URL with a `gclid` left over from an older visit
+ * would describe a campaign that never ran.
  */
 export function collectSubmissionContext(): SubmissionContext {
   if (!isBrowser()) {
     return { attribution: EMPTY_ATTRIBUTION, client: EMPTY_CLIENT }
   }
 
-  const params = new URLSearchParams(window.location.search)
+  const urlCampaign = parseCampaignParams(window.location.search)
+
+  // A URL carrying campaign params describes this visit directly and wins;
+  // otherwise the stored record supplies the whole first-touch block.
+  const firstTouch = hasCampaign(urlCampaign) ? null : readStoredAttribution()
+  const campaign: CampaignParams = firstTouch ?? urlCampaign
+
   const width = window.innerWidth || window.screen?.width || 0
 
   let timezone: string | null = null
@@ -106,14 +117,17 @@ export function collectSubmissionContext(): SubmissionContext {
 
   return {
     attribution: {
-      utmSource: nullable(params.get('utm_source')),
-      utmMedium: nullable(params.get('utm_medium')),
-      utmCampaign: nullable(params.get('utm_campaign')),
-      utmTerm: nullable(params.get('utm_term')),
-      utmContent: nullable(params.get('utm_content')),
-      gclid: nullable(params.get('gclid')),
-      referrer: nullable(document.referrer),
-      landingPath: window.location.pathname,
+      utmSource: campaign.utmSource,
+      utmMedium: campaign.utmMedium,
+      utmCampaign: campaign.utmCampaign,
+      utmTerm: campaign.utmTerm,
+      utmContent: campaign.utmContent,
+      gclid: campaign.gclid,
+      // Both follow the campaign block's source, so all eight fields describe
+      // the same visit. `landingPath` now means the page the visitor arrived
+      // on, not the page they happened to submit from.
+      referrer: firstTouch?.referrer ?? nullable(document.referrer),
+      landingPath: firstTouch?.landingPath ?? window.location.pathname,
     },
     client: {
       viewport: width ? classifyViewport(width) : null,


### PR DESCRIPTION
## Problem

Every paid conversion was arriving at the portal with null attribution. The Google Ads tagging is correct and PostHog receives the full query string; we lost it in our own client code.

`collectSubmissionContext()` read `window.location.search` at the moment it was called. For the audit that is `createAuditSession()`, when the visitor starts the wizard on `/audit`; for the contact form it is `onSubmit` on `/contact`. The ad's Final URL points at `/`, so by the time either ran the visitor had navigated client-side and the query string was gone.

All 49 campaign sessions in the last 60 days entered on `/`, none on `/audit` or `/contact`, so this path captured paid attribution essentially never. `document.referrer` survives SPA navigation, which is why the referrer field looked healthy and masked the problem.

## Change

Capture the campaign block at first touch into `localStorage` (`pts_attribution_v1`, 30-day lookback), and read it back as a fallback at submit time.

| File | |
|---|---|
| `src/lib/forms/attribution-store.ts` | **New.** Campaign-param parsing plus `readStoredAttribution()` / `captureAttribution()`. Every storage call try/catch-wrapped, matching `src/lib/audit/session.ts`. |
| `src/components/attribution-capture.tsx` | **New.** Client component, records first touch on every page load and route change. Renders null. |
| `app/layout.tsx` | Mounts it in a `<Suspense>` boundary. |
| `src/lib/forms/context.ts` | Resolves attribution as current URL → stored → null. Signature unchanged. |

`contact-section.tsx` and `audit/session.ts` are untouched: they call `collectSubmissionContext()` and inherit the fix. No wire-contract change, so the portal needs no deploy.

Two decisions worth flagging for review:

- **The campaign block resolves as a unit**, current URL or storage but never a mix. Pairing a `utm_source` read off this URL with a `gclid` left from an older visit would describe a campaign that never ran.
- **`<AttributionCapture />` is a sibling of `PostHogProvider`, not a child.** That provider returns its children untouched when `NEXT_PUBLIC_POSTHOG_KEY` is unset, which is the case in local dev, so nesting it would silently disable capture there and the first anyone would notice is null attribution in production again.

## Known consequences

- **`landing_path` changes meaning** at this deploy: rows before store the *submission* path, rows after store the *landing* path. Same column, two meanings. Worth noting wherever the field is analysed.
- **In-flight audits keep their null attribution.** `createAuditSession()` freezes context at mint time and localStorage holds it 7 days. Deliberately not bumping `AUDIT_SESSION_KEY` to flush them, that would wipe genuine in-progress audits to fix a handful of rows. Self-heals in a week.
- **Storage refused** (Safari private mode) degrades to exactly today's behaviour, which is the correct floor.

## Testing

`type-check`, `lint`, `prettier` and `build` are clean. Build output still shows `/`, `/audit` and `/contact` as `○ (Static)`, confirming the Suspense boundary prevents a dynamic de-opt.

The repo has no test runner, so the store's logic was exercised by transpiling it with the repo's own `tsc` and running it against a stubbed `localStorage` (scratchpad only, nothing added here). Sixteen assertions pass, covering: campaign surviving `/` → `/audit` navigation with `landing_path = /`; organic first touch; a second ad click overwriting wholesale with no field mixing; whitespace-only params not counting as a campaign; TTL expiry and just-inside-TTL; corrupt or hostile stored values; and storage refusal not throwing.

**Still needs a browser on the preview deploy** (§ Testing in the PRD): real portal rows for the `/` → `/audit` and `/` → `/contact` journeys, Safari private browsing, and a hydration-warning check.

## Not in scope

Google Ads Final URL change, historical backfill, `wbraid`/`gbraid`/`msclkid`/`fbclid` (needs a portal column), consent gating. All tracked as follow-ups in the PRD.

Plan: `docs/prds/006-first-touch-attribution/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)