### PR TITLE
Switch email send domain to hello@send.placetostandagency.com

### DIFF
--- a/app/actions/send-audit.ts
+++ b/app/actions/send-audit.ts
@@ -169,7 +169,7 @@ export async function sendAudit(
   // `.error` on every send.
   try {
     const teamEmail = await resend.emails.send({
-      from: 'Place To Stand <noreply@notifications.placetostandagency.com>',
+      from: 'Place To Stand <hello@send.placetostandagency.com>',
       to: ['hello@placetostandagency.com'],
       replyTo: email,
       subject: `New Opportunity Audit from ${name}`,
@@ -193,7 +193,7 @@ export async function sendAudit(
     }
 
     const clientEmail = await resend.emails.send({
-      from: 'Place To Stand <noreply@notifications.placetostandagency.com>',
+      from: 'Place To Stand <hello@send.placetostandagency.com>',
       to: [email],
       replyTo: 'hello@placetostandagency.com',
       subject: 'Your Place To Stand Opportunity Audit',

--- a/app/actions/send-contact.ts
+++ b/app/actions/send-contact.ts
@@ -171,7 +171,7 @@ export async function sendContact(
     const emailLines = [...detailLines]
 
     const teamEmail = await resend.emails.send({
-      from: 'Place To Stand <noreply@notifications.placetostandagency.com>',
+      from: 'Place To Stand <hello@send.placetostandagency.com>',
       to: ['hello@placetostandagency.com'],
       replyTo: email,
       subject: `New inquiry from ${name}`,
@@ -187,7 +187,7 @@ export async function sendContact(
     }
 
     const clientEmail = await resend.emails.send({
-      from: 'Place To Stand <noreply@notifications.placetostandagency.com>',
+      from: 'Place To Stand <hello@send.placetostandagency.com>',
       to: [email],
       replyTo: 'hello@placetostandagency.com',
       subject: 'Thanks for contacting Place To Stand',


### PR DESCRIPTION
## Summary
- Replaces `noreply@notifications.placetostandagency.com` with `hello@send.placetostandagency.com` in all four outbound `from:` addresses (contact form + audit flows)
- `to:` and `replyTo:` (`hello@placetostandagency.com`) unchanged

## Verification
- `send.placetostandagency.com` confirmed **verified** in Resend (us-east-1)
- Test send from `hello@send.placetostandagency.com` via Resend API: status `delivered`

🤖 Generated with [Claude Code](https://claude.com/claude-code)